### PR TITLE
Drop field interface in favor of native types

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,13 @@ Running `simdzone` on my system (Intel Core i7-1065G7) against an older
 
 GCC 12.2.1, release mode:
 ```
-$ time ./parser ../../zones/com.zone
-parsed 341535548 records
+$ time ./zone-bench parse ../../zones/com.zone
+Selected target haswell
+Parsed 341535548 records
 
-real    0m17.755s
-user    0m16.602s
-sys     0m1.105s
+real    0m20.629s
+user    0m19.328s
+sys     0m1.244s
 ```
 
 There are bound to be bugs and quite possibly smarter ways of implementing

--- a/src/fallback/name.h
+++ b/src/fallback/name.h
@@ -64,15 +64,15 @@ static inline void parse_name(
 {
   // a freestanding "@" denotes the current origin
   if (token->length == 1 && token->data[0] == '@') {
-    memcpy(&parser->rdata[parser->rdlength],
+    memcpy(&parser->rdata->octets[parser->rdata->length],
             parser->file->origin.octets,
             parser->file->origin.length);
-    parser->rdlength += parser->file->origin.length;
+    parser->rdata->length += parser->file->origin.length;
     return;
   }
 
   size_t length;
-  uint8_t *data = &parser->rdata[parser->rdlength];
+  uint8_t *data = &parser->rdata->octets[parser->rdata->length];
 
   scan_name(parser, type, field, token, data, &length);
   assert(length != 0);
@@ -82,41 +82,11 @@ static inline void parse_name(
   if (length > 256 - parser->file->origin.length)
     SYNTAX_ERROR(parser, "Invalid name in %s, exceeds 255 octets", field->name.data);
 
-  parser->rdlength += length;
-  memcpy(&parser->rdata[parser->rdlength],
+  parser->rdata->length += length;
+  memcpy(&parser->rdata->octets[parser->rdata->length],
           parser->file->origin.octets,
           parser->file->origin.length);
-  parser->rdlength += parser->file->origin.length;
-}
-
-static inline void parse_owner(
-  zone_parser_t *parser,
-  const zone_type_info_t *type,
-  const zone_field_info_t *field,
-  zone_token_t *token)
-{
-  // a freestanding "@" denotes the origin
-  if (token->length == 1 && token->data[0] == '@') {
-    memcpy(parser->file->owner.octets,
-           parser->file->origin.octets,
-           parser->file->origin.length);
-    parser->file->owner.length = parser->file->origin.length;
-    return;
-  }
-
-  scan_name(parser, type, field, token,
-            parser->file->owner.octets,
-           &parser->file->owner.length);
-
-  if (parser->file->owner.octets[parser->file->owner.length - 1] == 0)
-    return;
-  if (parser->file->owner.length > 255 - parser->file->origin.length)
-    SEMANTIC_ERROR(parser, "Invalid name in owner");
-
-  memcpy(&parser->file->owner.octets[parser->file->owner.length],
-          parser->file->origin.octets,
-          parser->file->origin.length);
-  parser->file->owner.length += parser->file->origin.length;
+  parser->rdata->length += parser->file->origin.length;
 }
 
 #endif // NAME_H

--- a/src/fallback/parser.c
+++ b/src/fallback/parser.c
@@ -28,6 +28,7 @@
 #include "generic/base32.h"
 #include "generic/base64.h"
 #include "generic/nsec.h"
+#include "visit.h"
 #include "parser.h"
 
 diagnostic_push()

--- a/src/fallback/text.h
+++ b/src/fallback/text.h
@@ -17,7 +17,7 @@ static inline void parse_string(
   const zone_field_info_t *field,
   zone_token_t *token)
 {
-  uint8_t *wire = &parser->rdata[parser->rdlength + 1];
+  uint8_t *wire = &parser->rdata->octets[parser->rdata->length + 1];
   uint8_t *limit = wire + 255;
   const char *text = token->data, *end = token->data + token->length;
 
@@ -58,8 +58,8 @@ static inline void parse_string(
     SYNTAX_ERROR(parser, "Invalid string in %s",
                  field->name.data);
 
-  parser->rdata[parser->rdlength] = (uint8_t)((wire - parser->rdata) - 1);
-  parser->rdlength += (size_t)(wire - parser->rdata);
+  parser->rdata->octets[parser->rdata->length] = (uint8_t)((wire - parser->rdata->octets) - 1);
+  parser->rdata->length += (size_t)(wire - parser->rdata->octets);
 }
 
 #endif // TEXT_H

--- a/src/fallback/type.h
+++ b/src/fallback/type.h
@@ -115,8 +115,8 @@ static inline void parse_type(
 
   scan_type(parser, type, field, token, &code);
   code = htons(code);
-  memcpy(&parser->rdata[parser->rdlength], &code, sizeof(code));
-  parser->rdlength += sizeof(uint16_t);
+  memcpy(&parser->rdata->octets[parser->rdata->length], &code, sizeof(code));
+  parser->rdata->length += sizeof(uint16_t);
 }
 
 #endif // TYPE_H

--- a/src/generic/base16.h
+++ b/src/generic/base16.h
@@ -41,10 +41,10 @@ static inline void parse_base16(
       }
 
       if (state == 0) {
-        parser->rdata[parser->rdlength] = (uint8_t)(ofs << 4);
+        parser->rdata->octets[parser->rdata->length] = (uint8_t)(ofs << 4);
         state = 1;
       } else {
-        parser->rdata[parser->rdlength++] |= ofs;
+        parser->rdata->octets[parser->rdata->length++] |= ofs;
         state = 0;
       }
     }
@@ -66,7 +66,7 @@ static inline void parse_salt(
   uint32_t state = 0;
 
   if (token->length == 1 && token->data[0] == '-') {
-    parser->rdata[parser->rdlength++] = 0;
+    parser->rdata->octets[parser->rdata->length++] = 0;
     return;
   }
 
@@ -74,7 +74,7 @@ static inline void parse_salt(
     SEMANTIC_ERROR(parser, "Invalid %s in %s",
                    field->name.data, type->name.data);
 
-  size_t rdlength = parser->rdlength++;
+  size_t rdlength = parser->rdata->length++;
 
   for (size_t i=0; i < token->length; i++) {
     const uint8_t ofs = zone_b16rmap[(uint8_t)token->data[i]];
@@ -91,10 +91,10 @@ static inline void parse_salt(
     }
 
     if (state == 0) {
-      parser->rdata[parser->rdlength] = (uint8_t)(ofs << 4);
+      parser->rdata->octets[parser->rdata->length] = (uint8_t)(ofs << 4);
       state = 1;
     } else {
-      parser->rdata[parser->rdlength++] |= ofs;
+      parser->rdata->octets[parser->rdata->length++] |= ofs;
       state = 0;
     }
   }
@@ -103,7 +103,7 @@ static inline void parse_salt(
     SEMANTIC_ERROR(parser, "Invalid %s in %s record",
                    field->name.data, type->name.data);
 
-  parser->rdata[rdlength] = (uint8_t)(parser->rdlength - rdlength);
+  parser->rdata->octets[rdlength] = (uint8_t)(parser->rdata->length - rdlength);
 }
 
 #endif // BASE16_H

--- a/src/generic/base32.h
+++ b/src/generic/base32.h
@@ -42,39 +42,39 @@ static inline void parse_base32(
 
       switch (state) {
         case 0:
-          parser->rdata[parser->rdlength  ]  = (uint8_t)(ofs << 3);
+          parser->rdata->octets[parser->rdata->length  ]  = (uint8_t)(ofs << 3);
           state = 1;
           break;
         case 1:
-          parser->rdata[parser->rdlength++] |= (uint8_t)(ofs >> 2);
-          parser->rdata[parser->rdlength  ]  = (uint8_t)(ofs << 6);
+          parser->rdata->octets[parser->rdata->length++] |= (uint8_t)(ofs >> 2);
+          parser->rdata->octets[parser->rdata->length  ]  = (uint8_t)(ofs << 6);
           state = 2;
           break;
         case 2:
-          parser->rdata[parser->rdlength  ] |= (uint8_t)(ofs << 1);
+          parser->rdata->octets[parser->rdata->length  ] |= (uint8_t)(ofs << 1);
           state = 3;
           break;
         case 3:
-          parser->rdata[parser->rdlength++] |= (uint8_t)(ofs >> 4);
-          parser->rdata[parser->rdlength  ]  = (uint8_t)(ofs << 4);
+          parser->rdata->octets[parser->rdata->length++] |= (uint8_t)(ofs >> 4);
+          parser->rdata->octets[parser->rdata->length  ]  = (uint8_t)(ofs << 4);
           state = 4;
           break;
         case 4:
-          parser->rdata[parser->rdlength++] |= (uint8_t)(ofs >> 1);
-          parser->rdata[parser->rdlength  ]  = (uint8_t)(ofs << 7);
+          parser->rdata->octets[parser->rdata->length++] |= (uint8_t)(ofs >> 1);
+          parser->rdata->octets[parser->rdata->length  ]  = (uint8_t)(ofs << 7);
           state = 5;
           break;
         case 5:
-          parser->rdata[parser->rdlength  ] |= (uint8_t)(ofs << 2);
+          parser->rdata->octets[parser->rdata->length  ] |= (uint8_t)(ofs << 2);
           state = 6;
           break;
         case 6:
-          parser->rdata[parser->rdlength++] |= (uint8_t)(ofs >> 3);
-          parser->rdata[parser->rdlength  ]  = (uint8_t)(ofs << 5);
+          parser->rdata->octets[parser->rdata->length++] |= (uint8_t)(ofs >> 3);
+          parser->rdata->octets[parser->rdata->length  ]  = (uint8_t)(ofs << 5);
           state = 7;
           break;
         case 7:
-          parser->rdata[parser->rdlength++] |= ofs;
+          parser->rdata->octets[parser->rdata->length++] |= ofs;
           state = 0;
           break;
       }

--- a/src/generic/base64.h
+++ b/src/generic/base64.h
@@ -46,22 +46,22 @@ static inline void parse_base64(
 
       switch (state) {
         case 0:
-          parser->rdata[parser->rdlength  ]  = (uint8_t)(ofs << 2);
+          parser->rdata->octets[parser->rdata->length  ]  = (uint8_t)(ofs << 2);
           state = 1;
           break;
         case 1:
-          parser->rdata[parser->rdlength++] |= (uint8_t)(ofs >> 4);
-          parser->rdata[parser->rdlength  ]  = (uint8_t)((ofs & 0x0f) << 4);
+          parser->rdata->octets[parser->rdata->length++] |= (uint8_t)(ofs >> 4);
+          parser->rdata->octets[parser->rdata->length  ]  = (uint8_t)((ofs & 0x0f) << 4);
           state = 2;
           break;
         case 2:
-          parser->rdata[parser->rdlength++] |= (uint8_t)(ofs >> 2);
-          parser->rdata[parser->rdlength  ]  = (uint8_t)((ofs & 0x03) << 6);
+          parser->rdata->octets[parser->rdata->length++] |= (uint8_t)(ofs >> 2);
+          parser->rdata->octets[parser->rdata->length  ]  = (uint8_t)((ofs & 0x03) << 6);
           state = 3;
           break;
         case 3:
-          parser->rdata[parser->rdlength++] |= ofs;
-          parser->rdata[parser->rdlength  ]  = 0;
+          parser->rdata->octets[parser->rdata->length++] |= ofs;
+          parser->rdata->octets[parser->rdata->length  ]  = 0;
           state = 0;
           break;
         default:

--- a/src/generic/ip4.h
+++ b/src/generic/ip4.h
@@ -13,6 +13,8 @@
 #include <ws2tcpip.h>
 #else
 #include <netinet/in.h>
+#include <arpa/inet.h>
+#include <sys/socket.h>
 #endif
 
 zone_always_inline()

--- a/src/generic/ip4.h
+++ b/src/generic/ip4.h
@@ -31,10 +31,10 @@ static inline void parse_ip4(
 
   memcpy(buf, token->data, token->length);
   buf[token->length] = '\0';
-  if (inet_pton(AF_INET, buf, &parser->rdata[parser->rdlength]) != 1)
+  if (inet_pton(AF_INET, buf, &parser->rdata->octets[parser->rdata->length]) != 1)
     SEMANTIC_ERROR(parser, "Invalid %s in %s",
                    field->name.data, type->name.data);
-  parser->rdlength += sizeof(struct in_addr);
+  parser->rdata->length += sizeof(struct in_addr);
 }
 
 #endif // IP4_H

--- a/src/generic/ip6.h
+++ b/src/generic/ip6.h
@@ -31,10 +31,10 @@ static inline void parse_ip6(
 
   memcpy(buf, token->data, token->length);
   buf[token->length] = '\0';
-  if (inet_pton(AF_INET6, buf, &parser->rdata[parser->rdlength]) != 1)
+  if (inet_pton(AF_INET6, buf, &parser->rdata->octets[parser->rdata->length]) != 1)
     SEMANTIC_ERROR(parser, "Invalid %s in %s",
                    field->name.data, type->name.data);
-  parser->rdlength += sizeof(struct in6_addr);
+  parser->rdata->length += sizeof(struct in6_addr);
 }
 
 #endif // IP6_H

--- a/src/generic/ip6.h
+++ b/src/generic/ip6.h
@@ -13,6 +13,8 @@
 #include <ws2tcpip.h>
 #else
 #include <netinet/in.h>
+#include <arpa/inet.h>
+#include <sys/socket.h>
 #endif
 
 zone_always_inline()

--- a/src/generic/name.h
+++ b/src/generic/name.h
@@ -131,15 +131,15 @@ static inline void parse_name(
 {
   // a freestanding "@" denotes the current origin
   if (token->length == 1 && token->data[0] == '@') {
-    memcpy(&parser->rdata[parser->rdlength],
+    memcpy(&parser->rdata->octets[parser->rdata->length],
             parser->file->origin.octets,
             parser->file->origin.length);
-    parser->rdlength += parser->file->origin.length;
+    parser->rdata->length += parser->file->origin.length;
     return;
   }
 
   size_t length;
-  uint8_t *data = &parser->rdata[parser->rdlength];
+  uint8_t *data = &parser->rdata->octets[parser->rdata->length];
 
   scan_name(parser, type, field, token, data, &length);
   assert(length != 0);
@@ -149,43 +149,11 @@ static inline void parse_name(
   if (length > 256 - parser->file->origin.length)
     SYNTAX_ERROR(parser, "Invalid name in %s, exceeds 255 octets", field->name.data);
 
-  parser->rdlength += length;
-  memcpy(&parser->rdata[parser->rdlength],
+  parser->rdata->length += length;
+  memcpy(&parser->rdata->octets[parser->rdata->length],
           parser->file->origin.octets,
           parser->file->origin.length);
-  parser->rdlength += parser->file->origin.length;
-}
-
-zone_always_inline()
-zone_nonnull_all()
-static inline void parse_owner(
-  zone_parser_t *parser,
-  const zone_type_info_t *type,
-  const zone_field_info_t *field,
-  zone_token_t *token)
-{
-  // a freestanding "@" denotes the origin
-  if (token->length == 1 && token->data[0] == '@') {
-    memcpy(parser->file->owner.octets,
-           parser->file->origin.octets,
-           parser->file->origin.length);
-    parser->file->owner.length = parser->file->origin.length;
-    return;
-  }
-
-  scan_name(parser, type, field, token,
-            parser->file->owner.octets,
-           &parser->file->owner.length);
-
-  if (parser->file->owner.octets[parser->file->owner.length - 1] == 0)
-    return;
-  if (parser->file->owner.length > 255 - parser->file->origin.length)
-    SEMANTIC_ERROR(parser, "Invalid name in owner");
-
-  memcpy(&parser->file->owner.octets[parser->file->owner.length],
-          parser->file->origin.octets,
-          parser->file->origin.length);
-  parser->file->owner.length += parser->file->origin.length;
+  parser->rdata->length += parser->file->origin.length;
 }
 
 #endif // NAME_H

--- a/src/generic/nsec.h
+++ b/src/generic/nsec.h
@@ -22,9 +22,9 @@ static inline void parse_nsec(
   uint16_t code;
   uint16_t highest_bit = 0;
 
-  uint8_t *data = &parser->rdata[parser->rdlength];
-  zone_nsec_t *bitmap = (void *)&parser->rdata[parser->rdlength];
-  assert(parser->rdlength < sizeof(parser->rdata) - (256 * (256 + 2)));
+  uint8_t *data = &parser->rdata->octets[parser->rdata->length];
+  zone_nsec_t *bitmap = (void *)&parser->rdata->octets[parser->rdata->length];
+  assert(parser->rdata->length < sizeof(parser->rdata) - (256 * (256 + 2)));
 
   // (mostly copied from NSD)
   // nsecbits contains up to 64K bits that represent the types available for
@@ -61,7 +61,7 @@ static inline void parse_nsec(
     memmove(&data[length+2], &bitmap[window][2], blocks);
   }
 
-  parser->rdlength += length;
+  parser->rdata->length += length;
 }
 
 #endif // NSEC_H

--- a/src/generic/number.h
+++ b/src/generic/number.h
@@ -36,17 +36,17 @@ static inline zone_return_t parse_int8(
                      field->name.data, type->name.data);
   }
 
-  parser->rdata[parser->rdlength] = (uint8_t)v;
-  parser->rdlength += sizeof(uint8_t);
-  return ZONE_RDATA;
+  parser->rdata->octets[parser->rdata->length] = (uint8_t)v;
+  parser->rdata->length += sizeof(uint8_t);
+  return 0;
 parse_symbol:
   if (!(symbol = zone_lookup(&field->symbols, token)))
     SYNTAX_ERROR(parser, "Invalid %s in %s, not a number",
                  field->name.data, type->name.data);
   assert(symbol->value <= UINT8_MAX);
-  parser->rdata[parser->rdlength] = (uint8_t)symbol->value;
-  parser->rdlength += sizeof(uint8_t);
-  return ZONE_RDATA;
+  parser->rdata->octets[parser->rdata->length] = (uint8_t)symbol->value;
+  parser->rdata->length += sizeof(uint8_t);
+  return 0;
 }
 
 zone_always_inline()
@@ -72,18 +72,18 @@ static inline zone_return_t parse_int16(
   }
 
   v16 = htons((uint16_t)v);
-  memcpy(&parser->rdata[parser->rdlength], &v16, sizeof(v16));
-  parser->rdlength += sizeof(uint16_t);
-  return ZONE_RDATA;
+  memcpy(&parser->rdata->octets[parser->rdata->length], &v16, sizeof(v16));
+  parser->rdata->length += sizeof(uint16_t);
+  return 0;
 parse_symbol:
   if (!(symbol = zone_lookup(&field->symbols, token)))
     SYNTAX_ERROR(parser, "Invalid %s in %s, not a number",
                  field->name.data, type->name.data);
   assert(symbol->value <= UINT16_MAX);
   v16 = htons((uint16_t)symbol->value);
-  memcpy(&parser->rdata[parser->rdlength], &v16, sizeof(v16));
-  parser->rdlength += sizeof(uint16_t);
-  return ZONE_RDATA;
+  memcpy(&parser->rdata->octets[parser->rdata->length], &v16, sizeof(v16));
+  parser->rdata->length += sizeof(uint16_t);
+  return 0;
 }
 
 zone_always_inline()
@@ -109,18 +109,18 @@ static inline zone_return_t parse_int32(
   }
 
   v32 = htonl((uint32_t)v);
-  memcpy(&parser->rdata[parser->rdlength], &v32, sizeof(v32));
-  parser->rdlength += sizeof(uint32_t);
-  return ZONE_RDATA;
+  memcpy(&parser->rdata->octets[parser->rdata->length], &v32, sizeof(v32));
+  parser->rdata->length += sizeof(uint32_t);
+  return 0;
 parse_symbol:
   if (!(symbol = zone_lookup(&field->symbols, token)))
     SYNTAX_ERROR(parser, "Invalid %s in %s, not a number",
                  field->name.data, type->name.data);
   assert(symbol->value <= UINT16_MAX);
   v32 = htonl(symbol->value);
-  memcpy(&parser->rdata[parser->rdlength], &v32, sizeof(v32));
-  parser->rdlength += sizeof(uint32_t);
-  return ZONE_RDATA;
+  memcpy(&parser->rdata->octets[parser->rdata->length], &v32, sizeof(v32));
+  parser->rdata->length += sizeof(uint32_t);
+  return 0;
 }
 
 #endif // NUMBER_H

--- a/src/generic/number.h
+++ b/src/generic/number.h
@@ -12,7 +12,7 @@
 #if _WIN32
 #include <winsock2.h>
 #else
-#include <arpa/inet.h>
+#include <netinet/in.h>
 #endif
 
 zone_always_inline()

--- a/src/generic/text.h
+++ b/src/generic/text.h
@@ -39,7 +39,7 @@ static inline void parse_string(
   zone_token_t *token)
 {
   string_block_t block;
-  uint8_t *wire = parser->rdata + 1;
+  uint8_t *wire = &parser->rdata->octets[parser->rdata->length + 1];
   const char *text = token->data, *limit = token->data + token->length;
 
   while (text < limit) {
@@ -76,13 +76,13 @@ static inline void parse_string(
       wire += block.length;
     }
 
-    if (wire - parser->rdata > 256)
+    if (wire - parser->rdata->octets > 256)
       SEMANTIC_ERROR(parser, "Invalid %s in %s, exceeds maximum length",
                      field->name.data, type->name.data);
   }
 
-  parser->rdata[parser->rdlength] = (uint8_t)((wire - parser->rdata) - 1);
-  parser->rdlength += (size_t)(wire - parser->rdata);
+  parser->rdata->octets[parser->rdata->length] = (uint8_t)((wire - parser->rdata->octets) - 1);
+  parser->rdata->length += (size_t)(wire - parser->rdata->octets);
 }
 
 #endif // TEXT_H

--- a/src/generic/time.h
+++ b/src/generic/time.h
@@ -77,8 +77,8 @@ static inline void parse_time(
   tm.tm_year -= 1900;
   tm.tm_mon -= 1;
   uint32_t time = htonl((uint32_t)mktime_from_utc(&tm));
-  memcpy(&parser->rdata[parser->rdlength], &time, sizeof(time));
-  parser->rdlength += sizeof(uint32_t);
+  memcpy(&parser->rdata->octets[parser->rdata->length], &time, sizeof(time));
+  parser->rdata->length += sizeof(uint32_t);
 }
 
 #endif // TIME_H

--- a/src/generic/ttl.h
+++ b/src/generic/ttl.h
@@ -121,8 +121,8 @@ static inline zone_return_t parse_ttl(
     return result;
   assert(seconds <= INT32_MAX);
   seconds = htonl(seconds);
-  memcpy(&parser->rdata[parser->rdlength], &seconds, sizeof(seconds));
-  parser->rdlength += sizeof(uint32_t);
+  memcpy(&parser->rdata->octets[parser->rdata->length], &seconds, sizeof(seconds));
+  parser->rdata->length += sizeof(uint32_t);
   return 0;
 }
 

--- a/src/generic/type.h
+++ b/src/generic/type.h
@@ -168,8 +168,8 @@ static inline void parse_type(
 
   scan_type(parser, type, field, token, &code);
   code = htons(code);
-  memcpy(&parser->rdata[parser->rdlength], &code, sizeof(code));
-  parser->rdlength += sizeof(uint16_t);
+  memcpy(&parser->rdata->octets[parser->rdata->length], &code, sizeof(code));
+  parser->rdata->length += sizeof(uint16_t);
 }
 
 #endif // TYPE_H

--- a/src/haswell/parser.c
+++ b/src/haswell/parser.c
@@ -30,6 +30,7 @@
 #include "generic/base32.h"
 #include "generic/base64.h"
 #include "generic/nsec.h"
+#include "visit.h"
 #include "parser.h"
 
 diagnostic_push()

--- a/src/parser.c
+++ b/src/parser.c
@@ -12,7 +12,7 @@
 #include <winsock2.h>
 #include <ws2ipdef.h>
 #else
-#include <arpa/inet.h>
+#include <netinet/in.h>
 #endif
 
 #include "zone.h"

--- a/src/visit.h
+++ b/src/visit.h
@@ -1,0 +1,37 @@
+/*
+ * visit.h -- some useful comment
+ *
+ * Copyright (c) 2022-2023, NLnet Labs. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ */
+#ifndef VISIT_H
+#define VISIT_H
+
+#include <setjmp.h>
+
+zone_always_inline()
+static inline void accept_rr(zone_parser_t *parser, void *user_data)
+{
+  zone_return_t result;
+
+  assert(parser->owner->length <= UINT8_MAX);
+  assert(parser->rdata->length <= UINT16_MAX);
+  result = parser->options.accept.add(
+    parser,
+    &(zone_name_t){ (uint8_t)parser->owner->length, parser->owner->octets },
+    parser->file->last_type,
+    parser->file->last_class,
+    parser->file->last_ttl,
+    (uint16_t)parser->rdata->length,
+    parser->rdata->octets,
+    user_data);
+
+  if (result < 0)
+    longjmp((void*)parser->environment, result);
+  assert((size_t)result < parser->cache.size);
+  parser->rdata = &parser->cache.rdata.blocks[result];
+}
+
+#endif // VISIT_H

--- a/src/westmere/parser.c
+++ b/src/westmere/parser.c
@@ -30,6 +30,7 @@
 #include "generic/base32.h"
 #include "generic/base64.h"
 #include "generic/nsec.h"
+#include "visit.h"
 #include "parser.h"
 
 diagnostic_push()

--- a/tests/types.c
+++ b/tests/types.c
@@ -31,26 +31,32 @@
   "\0\0\0\0\0\0\0\0" /* 56 - 63 */ \
   ""
 
+typedef struct field field_t;
+struct field {
+  zone_type_t type;
+  size_t length;
+  const uint8_t *octets;
+};
 
 #define IP4(options, rdata) \
-  { ZONE_IP4,  { NULL }, sizeof(struct in_addr), { (const uint8_t *)&(struct in_addr){ .s_addr = rdata } } }
+  { ZONE_IP4, sizeof(struct in_addr), (const uint8_t *)&(struct in_addr){ .s_addr = rdata } }
 
 #define NAME(options, ...) \
-  { ZONE_NAME, { NULL }, sizeof((uint8_t[]){ __VA_ARGS__ }), { (const uint8_t[]){ __VA_ARGS__ } } }
+  { ZONE_NAME, sizeof((uint8_t[]){ __VA_ARGS__ }), (const uint8_t[]){ __VA_ARGS__ } }
 
 #define RDATA(x) x, sizeof(x)/sizeof(x[0])
 
 
 static const char a_text[] = TEXT("host.example.com. 1 IN A 192.0.2.1");
 
-static const zone_field_t a[] = {
+static const field_t a[] = {
   IP4(0, 16908480)
 };
 
 
 static const char ns_text[] = TEXT("example.com. 1 IN NS host.example.com.");
 
-static const zone_field_t ns[] = {
+static const field_t ns[] = {
   NAME(ZONE_COMPRESSED,
        0x04, 0x68, 0x6f, 0x73, 0x74, 0x07, 0x65, 0x78,
        0x61, 0x6d, 0x70, 0x6c, 0x65, 0x03, 0x63, 0x6f,
@@ -62,7 +68,7 @@ typedef struct test test_t;
 struct test {
   const uint16_t type;
   const char *text;
-  const zone_field_t *fields;
+  const field_t *fields;
   const size_t count;
 };
 
@@ -71,13 +77,12 @@ static const test_t tests[] = {
   { ZONE_NS, ns_text, RDATA(ns) }
 };
 
-static zone_return_t accept_rr(
+static zone_return_t add_rr(
   zone_parser_t *parser,
-  const zone_field_t *owner,
-  const zone_field_t *type,
-  const zone_field_t *class,
-  const zone_field_t *ttl,
-  const zone_field_t *rdatas,
+  const zone_name_t *owner,
+  uint16_t type,
+  uint16_t class,
+  uint32_t ttl,
   uint16_t rdlength,
   const uint8_t *rdata,
   void *user_data)
@@ -87,10 +92,9 @@ static zone_return_t accept_rr(
   (void)owner;
   (void)class;
   (void)ttl;
-  (void)rdatas;
   (void)rdlength;
   (void)rdata;
-  assert_int_equal(*type->data.int16, test->type);
+  assert_int_equal(type, test->type);
   return ZONE_SUCCESS;
 }
 
@@ -102,15 +106,18 @@ void supported_types(void **state)
   for (size_t i = 0, n = sizeof(tests)/sizeof(tests[0]); i < n; i++) {
     test_t test = tests[i];
     zone_parser_t parser = { 0 };
+    zone_name_block_t name;
+    zone_rdata_block_t rdata;
+    zone_cache_t cache = { 1, &name, &rdata };
     zone_options_t options = { 0 };
     zone_return_t result;
 
-    options.accept = accept_rr;
+    options.accept.add = add_rr;
     options.origin = "example.com.";
     options.default_ttl = 3600;
     options.default_class = ZONE_IN;
 
-    result = zone_parse_string(&parser, &options, tests[i].text, strlen(tests[i].text), &test);
+    result = zone_parse_string(&parser, &options, &cache, tests[i].text, strlen(tests[i].text), &test);
     assert_int_equal(result, ZONE_SUCCESS);
   }
 }


### PR DESCRIPTION
This PR drops the field (descriptor) interface in favor of passing native types. Preparing descriptive fields only takes up extra time and it is unsure if the functionality is ever used (time will tell). Apart from that, the user is now required to pass buffers for storage of owners and RDATA. The idea here is that an authoritative name server may want to parser and commit in parallel to cut load times. A relatively small change. Apart from that, it also allows the user to chose how much buffer space to allocate. Of course, at least 1 is required, but if beneficial to use more than one thread and more space is available, it's now possible to do that. It also allows the user to allocate buffer space on heap, or simply leave it on stack to avoid memory leaks.