### PR TITLE
Save owner on $INCLUDE directive

### DIFF
--- a/include/zone.h
+++ b/include/zone.h
@@ -536,14 +536,11 @@ struct zone_options {
   /** Lax mode of operation. */
   /** Authoritative servers may choose to be more lenient when operating as
       as a secondary as data may have been transferred over AXFR/IXFR that
-      would have triggered a semantic error otherwise. */
+      would have triggered an error otherwise. */
   bool secondary;
-  /** Enable or disable $INCLUDE directive. */
-  enum {
-    ZONE_ALLOW_FILE_INCLUDES,
-    ZONE_ALLOW_INCLUDES,
-    ZONE_NEVER_ALLOW_INCLUDES
-  } allow_includes;
+  /** Disable $INCLUDE directive. */
+  /** Useful in setups where untrusted input may be offered. */
+  bool no_includes;
   const char *origin;
   uint32_t default_ttl;
   uint16_t default_class;

--- a/src/fallback/scanner.h
+++ b/src/fallback/scanner.h
@@ -278,6 +278,7 @@ terminate:
         assert(end == file->buffer.data + file->buffer.length);
         if (file->includer) {
           parser->file = file->includer;
+          parser->owner = &parser->file->owner;
           zone_close_file(parser, file);
         }
         *token = (zone_token_t){ 1, zone_end_of_file };

--- a/src/generic/scanner.h
+++ b/src/generic/scanner.h
@@ -377,6 +377,7 @@ terminate:
         assert(end == file->buffer.data + file->buffer.length);
         if (file->includer) {
           parser->file = file->includer;
+          parser->owner = &parser->file->owner;
           zone_close_file(parser, file);
         }
         *token = (zone_token_t){ 1, zone_end_of_file };

--- a/src/log.h
+++ b/src/log.h
@@ -42,4 +42,7 @@ zone_format_printf(6,7);
 #define OUT_OF_MEMORY(parser, ...) \
   RAISE(parser, ZONE_OUT_OF_MEMORY, __VA_ARGS__)
 
+#define NOT_PERMITTED(parser, ...) \
+  RAISE(parser, ZONE_NOT_PERMITTED, __VA_ARGS__)
+
 #endif // LOG_H

--- a/tests/include.c
+++ b/tests/include.c
@@ -165,13 +165,13 @@ void include_from_string(void **state)
   // verify $INCLUDE is denied by default when parsing strings.
   const char *str = input->includer.content;
   result = zone_parse_string(&parser, &options, &cache, str, strlen(str), NULL);
-  assert_int_equal(options.allow_includes, ZONE_ALLOW_FILE_INCLUDES);
-  assert_int_equal(result, ZONE_NOT_PERMITTED);
+  assert_false(options.no_includes);
+  assert_int_equal(result, ZONE_SUCCESS);
 
   // verify $INCLUDE is allowed and works as intented if configured.
-  options.allow_includes = ZONE_ALLOW_INCLUDES;
+  options.no_includes = true;
   result = zone_parse_string(&parser, &options, &cache, str, strlen(str), NULL);
-  assert_int_equal(result, ZONE_SUCCESS);
+  assert_int_equal(result, ZONE_NOT_PERMITTED);
 }
 
 //


### PR DESCRIPTION
This PR stores the owner with the includer when parsing an `$INCLUDE` directive and including a zone file. The owner is then restored after the included file has been processed. It also reworks `allow_includes` a little bit. Users should now set `no_includes` explicitly if `$INCLUDE` directives should not be allowed.