### PR TITLE
Add support for TLSA and SMIMEA RRs

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -654,6 +654,26 @@ int32_t zone_check_nsec3param_rdata(
 }
 
 zone_nonnull_all
+int32_t zone_check_tlsa_rdata(
+  zone_parser_t *parser, const zone_type_info_t *type)
+{
+  int32_t r;
+  size_t c = 0;
+  const size_t n = parser->rdata->length;
+  const uint8_t *o = parser->rdata->octets;
+  const zone_field_info_t *f = type->rdata.fields;
+
+  if ((r = add(&c, check_int8(parser, type, &f[0], o, n))) ||
+      (r = add(&c, check_int8(parser, type, &f[1], o+c, n-c))) ||
+      (r = add(&c, check_int8(parser, type, &f[2], o+c, n-c))))
+    return r;
+
+  if (c >= n)
+    SYNTAX_ERROR(parser, "Invalid %s", TNAME(type));
+  return accept_rr(parser);
+}
+
+zone_nonnull_all
 int32_t zone_check_l32_rdata(
   zone_parser_t *parser, const zone_type_info_t *type)
 {

--- a/src/types.h
+++ b/src/types.h
@@ -581,6 +581,34 @@ static int32_t parse_nsec3param_rdata(
 }
 
 zone_nonnull_all
+extern int32_t zone_check_tlsa_rdata(
+  zone_parser_t *parser, const zone_type_info_t *type);
+
+zone_nonnull_all
+static int32_t parse_tlsa_rdata(
+  zone_parser_t *parser, const zone_type_info_t *type, token_t *token)
+{
+  int32_t r;
+
+  if ((r = parse_int8(parser, type, &type->rdata.fields[0], token)) < 0)
+    return r;
+  lex(parser, token);
+  if ((r = parse_int8(parser, type, &type->rdata.fields[1], token)) < 0)
+    return r;
+  lex(parser, token);
+  if ((r = parse_int8(parser, type, &type->rdata.fields[2], token)) < 0)
+    return r;
+  lex(parser, token);
+  if ((r = parse_base16(parser, type, &type->rdata.fields[3], token)) < 0)
+    return r;
+  lex(parser, token);
+  if ((r = have_delimiter(parser, type, token)) < 0)
+    return r;
+
+  return accept_rr(parser);
+}
+
+zone_nonnull_all
 extern int32_t zone_check_l32_rdata(
   zone_parser_t *parser, const zone_type_info_t *type);
 
@@ -1045,6 +1073,20 @@ static const zone_field_info_t nsec3param_rdata_fields[] = {
   FIELD("salt", ZONE_STRING, ZONE_BASE16)
 };
 
+static const zone_field_info_t tlsa_rdata_fields[] = {
+  FIELD("usage", ZONE_INT8, 0),
+  FIELD("selector", ZONE_INT8, 0),
+  FIELD("matching type", ZONE_INT8, 0),
+  FIELD("certificate association data", ZONE_BLOB, ZONE_BASE16)
+};
+
+static const zone_field_info_t smimea_rdata_fields[] = {
+  FIELD("usage", ZONE_INT8, 0),
+  FIELD("selector", ZONE_INT8, 0),
+  FIELD("matching type", ZONE_INT8, 0),
+  FIELD("certificate association data", ZONE_BLOB, ZONE_BASE16)
+};
+
 static const zone_field_info_t cds_rdata_fields[] = {
   FIELD("keytag", ZONE_INT16, 0),
   FIELD("algorithm", ZONE_INT8, 0, SYMBOLS(ds_algorithm_symbols)),
@@ -1216,9 +1258,11 @@ static const type_descriptor_t types[] = {
                 zone_check_nsec3_rdata, parse_nsec3_rdata),
   TYPE("NSEC3PARAM", ZONE_NSEC3PARAM, ZONE_ANY, FIELDS(nsec3param_rdata_fields),
                      zone_check_nsec3param_rdata, parse_nsec3param_rdata),
+  TYPE("TLSA", ZONE_TLSA, ZONE_ANY, FIELDS(tlsa_rdata_fields),
+               zone_check_tlsa_rdata, parse_tlsa_rdata),
+  TYPE("SMIMEA", ZONE_SMIMEA, ZONE_ANY, FIELDS(smimea_rdata_fields),
+                 zone_check_tlsa_rdata, parse_tlsa_rdata),
 
-  UNKNOWN_TYPE(52), // TLSA
-  UNKNOWN_TYPE(53), // SMIMEA
   UNKNOWN_TYPE(54),
   UNKNOWN_TYPE(55), // HIP
   UNKNOWN_TYPE(56),

--- a/tests/types.c
+++ b/tests/types.c
@@ -293,6 +293,42 @@ static const rdata_t dhcid_rdata =
         0x94, 0xe8, 0xf1, 0x7c, 0xdb, 0x95, 0x00, 0x0d,
         0xa4, 0x8c, 0x40);
 
+static const char tlsa_text[] =
+  PAD(" TLSA 0 0 1 d2abde240d7cd3ee6b4b28c54df034b97983a1d16e8a410e4561cb106618e971");
+static const char tlsa_generic_text[] =
+  PAD(" TLSA \\# 35 00 00 01 ( d2abde240d7cd3ee6b4b28c54df034b9"
+      "                        7983a1d16e8a410e4561cb106618e971 )");
+static const rdata_t tlsa_rdata =
+  RDATA(/* usage */
+        0x00,
+        /* selector */
+        0x00,
+        /* matching type */
+        0x01,
+        /* certificate association data */
+        0xd2, 0xab, 0xde, 0x24, 0x0d, 0x7c, 0xd3, 0xee,
+        0x6b, 0x4b, 0x28, 0xc5, 0x4d, 0xf0, 0x34, 0xb9,
+        0x79, 0x83, 0xa1, 0xd1, 0x6e, 0x8a, 0x41, 0x0e,
+        0x45, 0x61, 0xcb, 0x10, 0x66, 0x18, 0xe9, 0x71);
+
+static const char smimea_text[] =
+  PAD(" SMIMEA 0 0 1 d2abde240d7cd3ee6b4b28c54df034b97983a1d16e8a410e4561cb106618e971");
+static const char smimea_generic_text[] =
+  PAD(" SMIMEA \\# 35 00 00 01 ( d2abde240d7cd3ee6b4b28c54df034b9"
+      "                          7983a1d16e8a410e4561cb106618e971 )");
+static const rdata_t smimea_rdata =
+  RDATA(/* usage */
+        0x00,
+        /* selector */
+        0x00,
+        /* matching type */
+        0x01,
+        /* certificate association data */
+        0xd2, 0xab, 0xde, 0x24, 0x0d, 0x7c, 0xd3, 0xee,
+        0x6b, 0x4b, 0x28, 0xc5, 0x4d, 0xf0, 0x34, 0xb9,
+        0x79, 0x83, 0xa1, 0xd1, 0x6e, 0x8a, 0x41, 0x0e,
+        0x45, 0x61, 0xcb, 0x10, 0x66, 0x18, 0xe9, 0x71);
+
 static const char cds_text[] =
   PAD(" CDS 58470 5 1 ( 3079F1593EBAD6DC121E202A8B766A6A4837206C )");
 static const char cds_generic_text[] =
@@ -498,6 +534,10 @@ static const test_t tests[] = {
   { ZONE_SSHFP, sshfp_generic_text, &sshfp_rdata },
   { ZONE_DHCID, dhcid_text, &dhcid_rdata },
   { ZONE_DHCID, dhcid_generic_text, &dhcid_rdata },
+  { ZONE_TLSA, tlsa_text, &tlsa_rdata },
+  { ZONE_TLSA, tlsa_generic_text, &tlsa_rdata },
+  { ZONE_SMIMEA, smimea_text, &smimea_rdata },
+  { ZONE_SMIMEA, smimea_generic_text, &smimea_rdata },
   { ZONE_CDS, cds_text, &cds_rdata },
   { ZONE_CDS, cds_generic_text, &cds_rdata },
   { ZONE_CDNSKEY, cdnskey_text, &cdnskey_rdata },


### PR DESCRIPTION
This PR adds support for `TLSA` and `SMIMEA` RRs defined in [RFC6698](https://datatracker.ietf.org/doc/html/rfc6698) and [RFC8162](https://datatracker.ietf.org/doc/html/rfc8162) respectively.