### PR TITLE
Add ClusterFuzzLite integration

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,6 @@
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y make autoconf automake libtool
+
+COPY . $SRC/simdzone
+COPY .clusterfuzzlite/build.sh $SRC/build.sh
+WORKDIR $SRC/simdzone

--- a/.clusterfuzzlite/README.md
+++ b/.clusterfuzzlite/README.md
@@ -1,0 +1,3 @@
+# ClusterFuzzLite set up
+This folder contains a fuzzing set for [ClusterFuzzLite](https://google.github.io/clusterfuzzlite).
+        

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -eu
+mkdir build
+cd build
+cmake ..
+make
+
+# Copy all fuzzer executables to $OUT/
+$CC $CFLAGS $LIB_FUZZING_ENGINE \
+  $SRC/simdzone/.clusterfuzzlite/zone_parse_string_fuzzer.c \
+  -o $OUT/zone_parse_string_fuzzer \
+  -I$SRC/simdzone/include \
+  -I$SRC/simdzone/build/include \
+  $SRC/simdzone/build/libzone.a

--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -1,0 +1,1 @@
+language: c

--- a/.clusterfuzzlite/zone_parse_string_fuzzer.c
+++ b/.clusterfuzzlite/zone_parse_string_fuzzer.c
@@ -20,10 +20,12 @@ static int32_t add_rr(zone_parser_t *parser, const zone_name_t *owner,
 }
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
-  // Ensure we have a bit of data.
-  if (size < 10) {
-    return 0;
-  }
+
+  size_t size_of_input = size + ZONE_BLOCK_SIZE + 1;
+  char *null_terminated = (char*)malloc(size_of_input);
+  memcpy(null_terminated, data, size);
+  null_terminated[size_of_input-1] = '\0';
+
   zone_parser_t parser = {0};
   zone_name_buffer_t name;
   zone_rdata_buffer_t rdata;
@@ -35,8 +37,9 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   options.default_ttl = 3600;
   options.default_class = 1;
 
-  zone_parse_string(&parser, &options, &buffers, (const char *)data, size,
+  zone_parse_string(&parser, &options, &buffers, null_terminated, size_of_input,
                     NULL);
 
+  free(null_terminated);
   return 0;
 }

--- a/.clusterfuzzlite/zone_parse_string_fuzzer.c
+++ b/.clusterfuzzlite/zone_parse_string_fuzzer.c
@@ -1,0 +1,42 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "zone.h"
+
+static int32_t add_rr(zone_parser_t *parser, const zone_name_t *owner,
+                      uint16_t type, uint16_t class, uint32_t ttl,
+                      uint16_t rdlength, const uint8_t *rdata,
+                      void *user_data) {
+  (void)parser;
+  (void)owner;
+  (void)type;
+  (void)class;
+  (void)ttl;
+  (void)rdlength;
+  (void)rdata;
+  (void)user_data;
+  return ZONE_SUCCESS;
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  // Ensure we have a bit of data.
+  if (size < 10) {
+    return 0;
+  }
+  zone_parser_t parser = {0};
+  zone_name_buffer_t name;
+  zone_rdata_buffer_t rdata;
+  zone_buffers_t buffers = {1, &name, &rdata};
+  zone_options_t options = {0};
+
+  options.accept.callback = add_rr;
+  options.origin = "example.com.";
+  options.default_ttl = 3600;
+  options.default_class = 1;
+
+  zone_parse_string(&parser, &options, &buffers, (const char *)data, size,
+                    NULL);
+
+  return 0;
+}

--- a/.clusterfuzzlite/zone_parse_string_fuzzer.c
+++ b/.clusterfuzzlite/zone_parse_string_fuzzer.c
@@ -20,11 +20,10 @@ static int32_t add_rr(zone_parser_t *parser, const zone_name_t *owner,
 }
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
-
   size_t size_of_input = size + ZONE_BLOCK_SIZE + 1;
   char *null_terminated = (char*)malloc(size_of_input);
   memcpy(null_terminated, data, size);
-  null_terminated[size_of_input-1] = '\0';
+  null_terminated[size] = '\0';
 
   zone_parser_t parser = {0};
   zone_name_buffer_t name;

--- a/.clusterfuzzlite/zone_parse_string_fuzzer.c
+++ b/.clusterfuzzlite/zone_parse_string_fuzzer.c
@@ -36,8 +36,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   options.default_ttl = 3600;
   options.default_class = 1;
 
-  zone_parse_string(&parser, &options, &buffers, null_terminated, size_of_input,
-                    NULL);
+  zone_parse_string(&parser, &options, &buffers, null_terminated, size, NULL);
 
   free(null_terminated);
   return 0;

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -1,0 +1,30 @@
+name: ClusterFuzzLite PR fuzzing
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [ main ]
+permissions: read-all
+jobs:
+  PR:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: [address]
+    steps:
+    - name: Build Fuzzers (${{ matrix.sanitizer }})
+      id: build
+      uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+      with:
+        sanitizer: ${{ matrix.sanitizer }}
+        language: c
+        bad-build-check: false
+    - name: Run Fuzzers (${{ matrix.sanitizer }})
+      id: run
+      uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        fuzz-seconds: 180
+        mode: 'code-change'
+        report-unreproducible-crashes: false
+        sanitizer: ${{ matrix.sanitizer }}


### PR DESCRIPTION
This adds fuzzing by way of [ClusterFuzzLite](https://google.github.io/clusterfuzzlite/), which is a GitHub action that will perform a short amount of fuzzing for new PRs. The goal is to use fuzzing to catch bugs that may be introduced by new PRs.

I added a fuzzer that targets `simd_parse_string`, and currently set the timeout of CFLite to 180 seconds. CFLite will flag if the fuzzer finds  any issues in the code introduced by a PR.

If you'd like to test this the way ClusterFuzzLite runs it (by way of OSS-Fuzz) you can use the steps:

```sh
git clone https://github.com/google/oss-fuzz
git clone https://github.com/DavidKorczynski/simdzone simdzone
cd simdzone
git checkout clusterfuzzlite

# Build the fuzzers in .clusterfuzzlite
python3 ../oss-fuzz/infra/helper.py build_fuzzers --external $PWD

# Run the fuzzer for 10 seconds
python3 ../oss-fuzz/infra/helper.py run_fuzzer --external $PWD zone_parse_string_fuzzer -- -max_total_time=10
```