### PR TITLE
Simply assume Windows is Little Endian

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,9 +225,6 @@ foreach(match ${matches})
 endforeach()
 
 file(GENERATE OUTPUT config.h CONTENT "${template}")
-# FIXME: we'll need to port this over to autoconf as well
-configure_file(src/generic/endian.h.in generic/endian.h @ONLY)
-
 
 if(BUILD_TESTING)
   add_subdirectory(tests)

--- a/src/generic/endian.h
+++ b/src/generic/endian.h
@@ -1,5 +1,5 @@
 /*
- * endian.h
+ * endian.h -- byte order abstractions
  *
  * Copyright (c) 2023, NLnet Labs.
  *
@@ -12,9 +12,9 @@
 #if _MSC_VER
 #include <stdlib.h>
 
-#define BYTE_ORDER @CMAKE_C_BYTE_ORDER@
 #define LITTLE_ENDIAN 1234
 #define BIG_ENDIAN 4321
+#define BYTE_ORDER LITTLE_ENDIAN
 
 #if BYTE_ORDER == LITTLE_ENDIAN
 #define htobe16(x) _byteswap_ushort(x)


### PR DESCRIPTION
Fixing support for using `autoconf` when used as a submodule in nsd. I've found no occurences of Windows ever running in Big Endian mode, even on [PowerPC](https://devblogs.microsoft.com/oldnewthing/20180806-00/?p=99425) (nice read), for which support was retired after NT4.0.