### PR TITLE
Require origin is specified in wire format

### DIFF
--- a/include/zone.h
+++ b/include/zone.h
@@ -314,8 +314,8 @@ typedef struct {
   bool no_includes;
   /** Enable 1h2m3s notations for TTLS. */
   bool pretty_ttls;
-  // FIXME: require origin to be in wire format? (#115)
-  const char *origin;
+  /** Origin in wire format. */
+  zone_name_t origin;
   uint32_t default_ttl;
   uint16_t default_class;
   struct {

--- a/src/bench.c
+++ b/src/bench.c
@@ -172,6 +172,8 @@ static void usage(const char *program)
   exit(EXIT_FAILURE);
 }
 
+static uint8_t root[] = { 0 };
+
 int main(int argc, char *argv[])
 {
   const char *name = NULL, *program = argv[0];
@@ -215,7 +217,8 @@ int main(int argc, char *argv[])
   zone_buffers_t buffers = { 1, &owner, &rdata };
 
   options.accept.callback = &bench_accept;
-  options.origin = ".";
+  options.origin.octets = root;
+  options.origin.length = 1;
   options.default_ttl = 3600;
   options.default_class = ZONE_IN;
 

--- a/tests/base32.c
+++ b/tests/base32.c
@@ -35,9 +35,11 @@ static int32_t add_rr(
   return ZONE_SUCCESS;
 }
 
-static const uint8_t foobar[] = {
-  'f', 'o', 'o', 'b', 'a', 'r'
-};
+static const uint8_t foobar[] =
+  { 'f', 'o', 'o', 'b', 'a', 'r' };
+
+static uint8_t origin[] =
+  { 7, 'e', 'x', 'a', 'm', 'p', 'l', 'e', 3, 'c', 'o', 'm', 0 };
 
 /*!cmocka */
 void base32_syntax(void **state)
@@ -78,7 +80,8 @@ void base32_syntax(void **state)
     fprintf(stderr, "INPUT: '%s'\n", rr);
 
     options.accept.callback = add_rr;
-    options.origin = "example.com.";
+    options.origin.octets = origin;
+    options.origin.length = sizeof(origin);
     options.default_ttl = 3600;
     options.default_class = ZONE_IN;
 

--- a/tests/include.c
+++ b/tests/include.c
@@ -152,6 +152,9 @@ static int32_t add_rr(
   return ZONE_SUCCESS;
 }
 
+static uint8_t origin[] =
+  { 7, 'e', 'x', 'a', 'm', 'p', 'l', 'e', 3, 'c', 'o', 'm', 0 };
+
 /*!cmocka setup:setup teardown:teardown */
 void include_from_string(void **state)
 {
@@ -164,7 +167,8 @@ void include_from_string(void **state)
   int32_t result;
 
   options.accept.callback = &add_rr;
-  options.origin = "example.com.";
+  options.origin.octets = origin;
+  options.origin.length = sizeof(origin);
   options.default_ttl = 3600;
   options.default_class = ZONE_IN;
 

--- a/tests/ip4.c
+++ b/tests/ip4.c
@@ -36,6 +36,9 @@ static int32_t add_rr(
 
 static const uint8_t address_192_0_2_1[] = { 192, 0, 2, 1 };
 
+static uint8_t origin[] =
+  { 7, 'e', 'x', 'a', 'm', 'p', 'l', 'e', 3, 'c', 'o', 'm', 0 };
+
 /*!cmocka */
 void ipv4_syntax(void **state)
 {
@@ -89,7 +92,8 @@ void ipv4_syntax(void **state)
     (void)snprintf(rr, sizeof(rr), " A %s", tests[i].address);
 
     options.accept.callback = add_rr;
-    options.origin = "example.com.";
+    options.origin.octets = origin;
+    options.origin.length = sizeof(origin);
     options.default_ttl = 3600;
     options.default_class = ZONE_IN;
 

--- a/tests/svcb.c
+++ b/tests/svcb.c
@@ -282,6 +282,9 @@ static int32_t add_rr(
   return ZONE_SUCCESS;
 }
 
+static uint8_t origin[] =
+  { 7, 'e', 'x', 'a', 'm', 'p', 'l', 'e', 3, 'c', 'o', 'm', 0 };
+
 /*!cmocka */
 void rfc9460_test_vectors(void **state)
 {
@@ -297,7 +300,8 @@ void rfc9460_test_vectors(void **state)
     int32_t result;
 
     options.accept.callback = add_rr;
-    options.origin = "example.com.";
+    options.origin.octets = origin;
+    options.origin.length = sizeof(origin);
     options.default_ttl = 3600;
     options.default_class = ZONE_IN;
 

--- a/tests/time.c
+++ b/tests/time.c
@@ -35,6 +35,9 @@ static int32_t add_rr(
   return 0;
 }
 
+static uint8_t origin[] =
+  { 7, 'e', 'x', 'a', 'm', 'p', 'l', 'e', 3, 'c', 'o', 'm', 0 };
+
 /*!cmocka */
 void time_stamp_syntax(void **state)
 {
@@ -89,7 +92,8 @@ void time_stamp_syntax(void **state)
     (void)snprintf(rr, size, FORMAT, tests[i].timestamp);
 
     options.accept.callback = add_rr;
-    options.origin = "example.com.";
+    options.origin.octets = origin;
+    options.origin.length = sizeof(origin);
     options.default_ttl = 3600;
     options.default_class = ZONE_IN;
 

--- a/tests/types.c
+++ b/tests/types.c
@@ -980,6 +980,9 @@ static int32_t add_rr(
   return ZONE_SUCCESS;
 }
 
+static uint8_t origin[] =
+  { 7, 'e', 'x', 'a', 'm', 'p', 'l', 'e', 3, 'c', 'o', 'm', 0 };
+
 /*!cmocka */
 void supported_types(void **state)
 {
@@ -995,7 +998,8 @@ void supported_types(void **state)
     int32_t result;
 
     options.accept.callback = add_rr;
-    options.origin = "example.com.";
+    options.origin.octets = origin;
+    options.origin.length = sizeof(origin);
     options.default_ttl = 3600;
     options.default_class = ZONE_IN;
 


### PR DESCRIPTION
Specifying the origin in wire format makes sense as name servers typically have it available. For client applications that may not be the case, so it may make sense to eventually offer a function to parse it eventually(?)