### PR TITLE
Make relative $INCLUDE relative to includer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,7 +132,7 @@ endif()
 
 add_library(zone STATIC)
 if(WIN32)
-  target_link_libraries(zone INTERFACE ws2_32)
+  target_link_libraries(zone INTERFACE shlwapi)
 endif()
 
 generate_export_header(


### PR DESCRIPTION
Relative `$INCLUDE` directives fail if the path is not relative to the current working directory, fix that.