### PR TITLE
Make octets member in name constant

### DIFF
--- a/include/zone.h
+++ b/include/zone.h
@@ -287,7 +287,7 @@ typedef void(*zone_log_t)(
 typedef struct zone_name zone_name_t;
 struct zone_name {
   uint8_t length;
-  uint8_t *octets;
+  const uint8_t *octets;
 };
 
 // invoked for each resource record (host order). header (owner, type, class and ttl)


### PR DESCRIPTION
What it says on the tin. The `zone_name_t` is used to communicate a domain name as a vector of octets that is not guaranteed to be padded, it must not be modified.