### PR TITLE
Fix some bugs and drop support for quoted domain names

### DIFF
--- a/src/generic/name.h
+++ b/src/generic/name.h
@@ -145,7 +145,10 @@ escaped:
     }
 
     octets[label] = (uint8_t)(length - label);
-  } while (left);
+  } while (left && length < 255);
+
+  if (length > 255)
+    return -1;
 
   *lengthp = length + 1;
   return carry == 0;

--- a/src/generic/parser.h
+++ b/src/generic/parser.h
@@ -365,6 +365,13 @@ static really_inline bool is_delimiter(const token_t *token)
 
 nonnull_all
 warn_unused_result
+static really_inline bool is_line_feed(const token_t *token)
+{
+  return token->code == LINE_FEED;
+}
+
+nonnull_all
+warn_unused_result
 static really_inline bool is_end_of_file(const token_t *token)
 {
   return token->code == 0;

--- a/src/generic/parser.h
+++ b/src/generic/parser.h
@@ -883,6 +883,7 @@ static never_inline int32_t maybe_take_delimiter(
         token->length = 1;
         parser->file->span++;
         parser->file->start_of_line = classify[ (uint8_t)*(token->data+1) ] != BLANK;
+        parser->file->fields.head++;
         return 0;
       }
     } else if (token->code == END_OF_FILE) {

--- a/src/generic/types.h
+++ b/src/generic/types.h
@@ -292,7 +292,7 @@ static int32_t parse_ns_rdata(
   int32_t code;
   const rdata_info_t *fields = type->rdata.fields;
 
-  if ((code = have_contiguous_or_quoted(parser, type, &fields[0], token)) < 0)
+  if ((code = have_contiguous(parser, type, &fields[0], token)) < 0)
     return code;
   if ((code = parse_name(parser, type, &fields[0], rdata, token)) < 0)
     return code;
@@ -332,11 +332,11 @@ static int32_t parse_soa_rdata(
   int32_t code;
   const rdata_info_t *fields = type->rdata.fields;
 
-  if ((code = have_contiguous_or_quoted(parser, type, &fields[0], token)) < 0)
+  if ((code = have_contiguous(parser, type, &fields[0], token)) < 0)
     return code;
   if ((code = parse_name(parser, type, &fields[0], rdata, token)) < 0)
     return code;
-  if ((code = take_contiguous_or_quoted(parser, type, &fields[1], token)) < 0)
+  if ((code = take_contiguous(parser, type, &fields[1], token)) < 0)
     return code;
   if ((code = parse_name(parser, type, &fields[1], rdata, token)) < 0)
     return code;
@@ -501,11 +501,11 @@ static int32_t parse_minfo_rdata(
   int32_t code;
   const rdata_info_t *fields = type->rdata.fields;
 
-  if ((code = have_contiguous_or_quoted(parser, type, &fields[0], token)) < 0)
+  if ((code = have_contiguous(parser, type, &fields[0], token)) < 0)
     return code;
   if ((code = parse_name(parser, type, &fields[0], rdata, token)) < 0)
     return code;
-  if ((code = take_contiguous_or_quoted(parser, type, &fields[1], token)) < 0)
+  if ((code = take_contiguous(parser, type, &fields[1], token)) < 0)
     return code;
   if ((code = parse_name(parser, type, &fields[1], rdata, token)) < 0)
     return code;
@@ -703,7 +703,7 @@ static int32_t parse_rt_rdata(
     return code;
   if ((code = parse_int16(parser, type, &fields[0], rdata, token)) < 0)
     return code;
-  if ((code = take_contiguous_or_quoted(parser, type, &fields[1], token)) < 0)
+  if ((code = take_contiguous(parser, type, &fields[1], token)) < 0)
     return code;
   if ((code = parse_name(parser, type, &fields[1], rdata, token)) < 0)
     return code;
@@ -790,7 +790,7 @@ static int32_t parse_nsap_ptr_rdata(
   int32_t code;
   const rdata_info_t *fields = type->rdata.fields;
 
-  if ((code = have_contiguous_or_quoted(parser, type, &fields[0], token)) < 0)
+  if ((code = have_contiguous(parser, type, &fields[0], token)) < 0)
     return code;
   if ((code = parse_name(parser, type, &fields[0], rdata, token)) < 0)
     return code;
@@ -882,11 +882,11 @@ static int32_t parse_px_rdata(
     return code;
   if ((code = parse_int16(parser, type, &fields[0], rdata, token)) < 0)
     return code;
-  if ((code = take_contiguous_or_quoted(parser, type, &fields[1], token)) < 0)
+  if ((code = take_contiguous(parser, type, &fields[1], token)) < 0)
     return code;
   if ((code = parse_name(parser, type, &fields[1], rdata, token)) < 0)
     return code;
-  if ((code = take_contiguous_or_quoted(parser, type, &fields[2], token)) < 0)
+  if ((code = take_contiguous(parser, type, &fields[2], token)) < 0)
     return code;
   if ((code = parse_name(parser, type, &fields[2], rdata, token)) < 0)
     return code;
@@ -1117,7 +1117,7 @@ static int32_t parse_nxt_rdata(
   int32_t code;
   const rdata_info_t *fields = type->rdata.fields;
 
-  if ((code = have_contiguous_or_quoted(parser, type, &fields[0], token)) < 0)
+  if ((code = have_contiguous(parser, type, &fields[0], token)) < 0)
     return code;
   if ((code = parse_name(parser, type, &fields[0], rdata, token)) < 0)
     return code;
@@ -1168,7 +1168,7 @@ static int32_t parse_srv_rdata(
     return code;
   if ((code = parse_int16(parser, type, &fields[2], rdata, token)) < 0)
     return code;
-  if ((code = take_contiguous_or_quoted(parser, type, &fields[3], token)) < 0)
+  if ((code = take_contiguous(parser, type, &fields[3], token)) < 0)
     return code;
   if ((code = parse_name(parser, type, &fields[3], rdata, token)) < 0)
     return code;
@@ -1213,7 +1213,7 @@ static int32_t parse_naptr_rdata(
     return code;
   if ((code = parse_string(parser, type, &fields[4], rdata, token)) < 0)
     return code;
-  if ((code = take_contiguous_or_quoted(parser, type, &fields[5], token)) < 0)
+  if ((code = take_contiguous(parser, type, &fields[5], token)) < 0)
     return code;
   if ((code = parse_name(parser, type, &fields[5], rdata, token)) < 0)
     return code;
@@ -1504,28 +1504,24 @@ static int32_t parse_ipseckey_rdata(
     return code;
   if ((code = parse_int8(parser, type, &fields[2], rdata, token)) < 0)
     return code;
+  if ((code = take_contiguous(parser, type, &fields[3], token)) < 0)
+    return code;
 
   switch (octets[1]) {
     case 1: /* IPv4 address */
       type = (const type_info_t *)ipseckey_ipv4;
       fields = type->rdata.fields;
-      if ((code = take_contiguous(parser, type, &fields[3], token)) < 0)
-        return code;
       if ((code = parse_ip4(parser, type, &fields[3], rdata, token)) < 0)
         return code;
       break;
     case 2: /* IPv6 address */
       type = (const type_info_t *)ipseckey_ipv6;
       fields = type->rdata.fields;
-      if ((code = take_contiguous(parser, type, &fields[3], token)) < 0)
-        return code;
       if ((code = parse_ip6(parser, type, &fields[3], rdata, token)) < 0)
         return code;
       break;
     case 0: /* no gateway */
     case 3: /* domain name */
-      if ((code = take_contiguous_or_quoted(parser, type, &fields[3], token)) < 0)
-        return code;
       if ((code = parse_name(parser, type, &fields[3], rdata, token)) < 0)
         return code;
       break;
@@ -1608,7 +1604,7 @@ static int32_t parse_rrsig_rdata(
     return code;
   if ((code = parse_int16(parser, type, &fields[6], rdata, token)) < 0)
     return code;
-  if ((code = take_contiguous_or_quoted(parser, type, &fields[7], token)) < 0)
+  if ((code = take_contiguous(parser, type, &fields[7], token)) < 0)
     return code;
   if ((code = parse_name(parser, type, &fields[7], rdata, token)) < 0)
     return code;
@@ -1645,7 +1641,7 @@ static int32_t parse_nsec_rdata(
   int32_t code;
   const rdata_info_t *fields = type->rdata.fields;
 
-  if ((code = have_contiguous_or_quoted(parser, type, &fields[0], token)) < 0)
+  if ((code = have_contiguous(parser, type, &fields[0], token)) < 0)
     return code;
   if ((code = parse_name(parser, type, &fields[0], rdata, token)) < 0)
     return code;
@@ -1928,7 +1924,7 @@ static int32_t parse_hip_rdata(
   memcpy(&octets[2], &pk_length, sizeof(pk_length));
 
   take(parser, token);
-  while (is_contiguous_or_quoted(token)) {
+  while (is_contiguous(token)) {
     if ((code = parse_name(parser, type, &fields[5], rdata, token)) < 0)
       return code;
     take(parser, token);
@@ -2061,7 +2057,7 @@ static int32_t parse_svcb_rdata(
     return code;
   if ((code = parse_int16(parser, type, &fields[0], rdata, token)) < 0)
     return code;
-  if ((code = take_contiguous_or_quoted(parser, type, &fields[1], token)) < 0)
+  if ((code = take_contiguous(parser, type, &fields[1], token)) < 0)
     return code;
   if ((code = parse_name(parser, type, &fields[1], rdata, token)) < 0)
     return code;
@@ -2090,7 +2086,7 @@ static int32_t parse_https_rdata(
     return code;
   if ((code = parse_int16(parser, type, &fields[0], rdata, token)) < 0)
     return code;
-  if ((code = take_contiguous_or_quoted(parser, type, &fields[1], token)) < 0)
+  if ((code = take_contiguous(parser, type, &fields[1], token)) < 0)
     return code;
   if ((code = parse_name(parser, type, &fields[1], rdata, token)) < 0)
     return code;

--- a/tests/syntax.c
+++ b/tests/syntax.c
@@ -110,3 +110,111 @@ void newlines(void **state)
     assert_int_equal(result, ZONE_SUCCESS);
   }
 }
+
+static int32_t name_test_accept_rr(
+  zone_parser_t *parser,
+  const zone_name_t *owner,
+  uint16_t type,
+  uint16_t class,
+  uint32_t ttl,
+  uint16_t rdlength,
+  const uint8_t *rdata,
+  void *user_data)
+{
+  (void)parser;
+  (void)owner;
+  (void)type;
+  (void)class;
+  (void)ttl;
+  (void)rdlength;
+  (void)rdata;
+  (void)user_data;
+  return 0;
+}
+
+/*!cmocka */
+void names(void **state)
+{
+  (void)state;
+
+  static const char only_rel_label_too_long[] =
+    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+  static const char only_abs_label_too_long[] =
+    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef.";
+
+  static const char first_label_too_long[] =
+    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef.foo.";
+
+  static const char last_rel_label_too_long[] =
+    "foo.0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+  static const char last_abs_label_too_long[] =
+    "foo.0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef.";
+
+  static const char rel_name_too_long[] =
+    "0123456789abcdef0123456789abcde."   /*  32 */
+    "0123456789abcdef0123456789abcde."   /*  64 */
+    "0123456789abcdef0123456789abcde."   /*  96 */
+    "0123456789abcdef0123456789abcde."   /* 128 */
+    "0123456789abcdef0123456789abcde."   /* 160 */
+    "0123456789abcdef0123456789abcde."   /* 192 */
+    "0123456789abcdef0123456789abcde."   /* 224 */
+    "0123456789abcdef0123456789a"; /* .foo. 256 */
+
+  static const char abs_name_too_long[] =
+    "0123456789abcdef0123456789abcde."  /*  32 */
+    "0123456789abcdef0123456789abcde."  /*  64 */
+    "0123456789abcdef0123456789abcde."  /*  96 */
+    "0123456789abcdef0123456789abcde."  /* 128 */
+    "0123456789abcdef0123456789abcde."  /* 160 */
+    "0123456789abcdef0123456789abcde."  /* 192 */
+    "0123456789abcdef0123456789abcde."  /* 224 */
+    "0123456789abcdef0123456789abcde."; /* 256 */
+
+  static const char only_null_labels[] = "..";
+  static const char last_label_is_null[] = "foo..";
+  static const char first_label_is_null[] = "..foo";
+
+  static const struct {
+    const char *input;
+    int32_t code;
+  } tests[] = {
+    { only_rel_label_too_long,  ZONE_SYNTAX_ERROR },
+    { only_abs_label_too_long,  ZONE_SYNTAX_ERROR },
+    { first_label_too_long,     ZONE_SYNTAX_ERROR },
+    { last_rel_label_too_long,  ZONE_SYNTAX_ERROR },
+    { last_abs_label_too_long,  ZONE_SYNTAX_ERROR },
+    { rel_name_too_long,        ZONE_SYNTAX_ERROR },
+    { abs_name_too_long,        ZONE_SYNTAX_ERROR },
+    { only_null_labels,         ZONE_SYNTAX_ERROR },
+    { last_label_is_null,       ZONE_SYNTAX_ERROR },
+    { first_label_is_null,      ZONE_SYNTAX_ERROR }
+  };
+
+  static const uint8_t origin[] = { 3, 'f', 'o', 'o', 0 };
+
+  for (size_t i=0, n=sizeof(tests)/sizeof(tests[0]); i < n; i++) {
+    zone_parser_t parser = { 0 };
+    zone_name_buffer_t name;
+    zone_rdata_buffer_t rdata;
+    zone_buffers_t buffers = { 1, &name, &rdata };
+    zone_options_t options = { 0 };
+    char input[512] = { 0 };
+    size_t length;
+    int32_t code;
+
+    (void)snprintf(input, sizeof(input), "%s A 192.168.0.1", tests[i].input);
+    length = strlen(input);
+
+    options.accept.callback = name_test_accept_rr;
+    options.origin.octets = origin;
+    options.origin.length = sizeof(origin);
+    options.default_ttl = 3600;
+    options.default_class = ZONE_IN;
+
+    fprintf(stderr, "INPUT: '%s'\n", input);
+    code = zone_parse_string(&parser, &options, &buffers, input, length, NULL);
+    assert_int_equal(code, tests[i].code);
+  }
+}


### PR DESCRIPTION
This PR fixes some bugs and moves checking for `<blank>` or `<owner>` up. As as a result, there's less code in the hot path and this speeds up the parser. Apart from that, it also drops support for quoting domain names. While RFC1035 mentions labels can be quoted, support in implementations is a hit-and-miss, with some implementations implementing different behavior for domain names that occur as the owner or in the RDATA section. For consistency, remove support all together.