### PR TITLE
Fix parsing of escape sequences in strings

### DIFF
--- a/src/generic/format.h
+++ b/src/generic/format.h
@@ -106,6 +106,47 @@ relative:
 }
 
 nonnull_all
+static really_inline int32_t parse_string(
+  parser_t *parser,
+  const type_info_t *type,
+  const rdata_info_t *field,
+  rdata_t *rdata,
+  const token_t *token)
+{
+  if (rdata->limit == rdata->octets)
+    SYNTAX_ERROR(parser, "Invalid %s in %s", NAME(type), NAME(field));
+  assert(rdata->limit > rdata->octets);
+
+  int32_t length;
+  uint8_t *octets = rdata->octets + 1;
+  const uint8_t *limit = rdata->limit;
+
+  if (rdata->limit - rdata->octets > (1 + 255))
+    limit = rdata->octets + 1 + 255;
+  if ((length = scan_string(token->data, token->length, octets, limit)) == -1)
+    SYNTAX_ERROR(parser, "Invalid %s in %s", NAME(type), NAME(field));
+  *rdata->octets = (uint8_t)length;
+  rdata->octets += 1u + (uint32_t)length;
+  return 0;
+}
+
+nonnull_all
+static really_inline int32_t parse_text(
+  parser_t *parser,
+  const type_info_t *type,
+  const rdata_info_t *field,
+  rdata_t *rdata,
+  const token_t *token)
+{
+  int32_t length;
+
+  if ((length = scan_string(token->data, token->length, rdata->octets, rdata->limit)) == -1)
+    SYNTAX_ERROR(parser, "Invalid %s in %s", NAME(type), NAME(field));
+  rdata->octets += (uint32_t)length;
+  return 0;
+}
+
+nonnull_all
 static really_inline int32_t parse_rr(
   parser_t *parser, token_t *token)
 {

--- a/src/generic/types.h
+++ b/src/generic/types.h
@@ -32,6 +32,22 @@ static really_inline int32_t parse_name(
   rdata_t *rdata,
   const token_t *token);
 
+nonnull_all
+static really_inline int32_t parse_string(
+  parser_t *parser,
+  const type_info_t *type,
+  const rdata_info_t *field,
+  rdata_t *rdata,
+  const token_t *token);
+
+nonnull_all
+static really_inline int32_t parse_text(
+  parser_t *parser,
+  const type_info_t *type,
+  const rdata_info_t *field,
+  rdata_t *rdata,
+  const token_t *token);
+
 #define FIELDS(fields) \
   { (sizeof(fields)/sizeof(fields[0])), fields }
 


### PR DESCRIPTION
Found using `bug090_000_txt` test case in NSD.