### PR TITLE
Review fix parse of type RRSIG in unknown RR format.

### DIFF
--- a/src/generic/types.h
+++ b/src/generic/types.h
@@ -1580,7 +1580,7 @@ static int32_t check_rrsig_rr(
       (r = check(&c, check_name(parser, type, &f[7], o+c, n-c))))
     return r;
 
-  if (c != n)
+  if (c > n)
     SYNTAX_ERROR(parser, "Invalid %s", NAME(type));
   return accept_rr(parser, type, rdata);
 }


### PR DESCRIPTION
This fixes the parse of type RRSIG in unknown RR format. It would reject it because the base64 data causes the lengths to mismatch. This fix allows zero length base64 rdata.