### PR TITLE
Fixes for SVCB and HTTPS RRs

### DIFF
--- a/src/generic/parser.h
+++ b/src/generic/parser.h
@@ -79,7 +79,7 @@ typedef int32_t (*parse_svc_param_t)(
 struct svc_param_info {
   mnemonic_t name;
   uint32_t has_value;
-  parse_svc_param_t parse, parse_non_strict;
+  parse_svc_param_t parse, parse_lax;
 };
 
 struct rdata_info {

--- a/src/generic/parser.h
+++ b/src/generic/parser.h
@@ -78,7 +78,7 @@ typedef int32_t (*parse_svc_param_t)(
 
 struct svc_param_info {
   mnemonic_t name;
-  bool has_value;
+  uint32_t has_value;
   parse_svc_param_t parse, parse_non_strict;
 };
 

--- a/src/generic/svcb.h
+++ b/src/generic/svcb.h
@@ -272,40 +272,6 @@ static int32_t parse_dohpath(
 }
 
 nonnull_all
-static int32_t parse_dohpath_non_strict(
-  parser_t *parser,
-  const type_info_t *type,
-  const rdata_info_t *field,
-  uint16_t key,
-  const svc_param_info_t *param,
-  rdata_t *rdata,
-  const token_t *token)
-{
-  const char *t = token->data, *te = t + token->length;
-
-  (void)field;
-  (void)key;
-  (void)param;
-
-  // FIXME: easily optimized using SIMD (and possibly SWAR)
-  while ((t < te) & (rdata->octets < rdata->limit)) {
-    *rdata->octets = (uint8_t)*t;
-    if (*t == '\\') {
-      uint32_t o;
-      if (!(o = unescape(t, rdata->octets)))
-        SYNTAX_ERROR(parser, "Invalid dohpath in %s", NAME(type));
-      rdata->octets += 1; t += o;
-    } else {
-      rdata->octets += 1; t += 1;
-    }
-  }
-
-  if (t != te || rdata->octets >= rdata->limit)
-    SYNTAX_ERROR(parser, "Invalid dohpath in %s", NAME(type));
-  return 0;
-}
-
-nonnull_all
 static int32_t parse_unknown(
   parser_t *parser,
   const type_info_t *type,
@@ -367,7 +333,7 @@ static int32_t parse_unknown(
 /** @} */
 
 nonnull_all
-static int32_t parse_mandatory_non_strict(
+static int32_t parse_mandatory_lax(
   parser_t *parser,
   const type_info_t *type,
   const rdata_info_t *field,
@@ -389,27 +355,43 @@ static int32_t parse_mandatory(
 #define SVC_PARAM(name, key, value, parse, parse_non_strict) \
   { { { name, sizeof(name) - 1 }, key }, value, parse, parse_non_strict }
 
+#define NO_VALUE (0u)
+#define OPTIONAL_VALUE (1u << 1)
+#define MANDATORY_VALUE (1u << 2)
+
 static const svc_param_info_t svc_params[] = {
-  SVC_PARAM("mandatory", 0u, 2u, parse_mandatory, parse_mandatory_non_strict),
-  SVC_PARAM("alpn", 1u, 2u, parse_alpn, parse_alpn),
+  // RFC9460 section 8:
+  //   The presentation value SHALL be a comma-separated list (Appendix A.1)
+  //   of one or more valid SvcParamKeys ...
+  SVC_PARAM("mandatory", 0u, MANDATORY_VALUE,
+            parse_mandatory, parse_mandatory_lax),
+  SVC_PARAM("alpn", 1u, MANDATORY_VALUE, parse_alpn, parse_alpn),
   // RFC9460 section 7.1.1:
   //   For "no-default-alpn", the presentation and wire format values MUST be
   //   empty. When "no-default-alpn" is specified in an RR, "alpn" must also be
   //   specified in order for the RR to be "self-consistent" (Section 2.4.3).
-  SVC_PARAM("no-default-alpn", 0u, 0u, 0, 0),
-  SVC_PARAM("port", 3u, 2u, parse_port, parse_port),
-  SVC_PARAM("ipv4hint", 4u, 2u, parse_ipv4hint, parse_ipv4hint),
-  SVC_PARAM("ech", 5u, 2u, parse_ech, parse_ech),
-  SVC_PARAM("ipv6hint", 6u, 2u, parse_ipv6hint, parse_ipv6hint),
+  SVC_PARAM("no-default-alpn", 2u, NO_VALUE, 0, 0),
+  // RFC9460 section 7.2:
+  //   The presentation value of the SvcParamValue is a single decimal integer
+  //   between 0 and 65535 in ASCII. ...
+  SVC_PARAM("port", 3u, MANDATORY_VALUE, parse_port, parse_port),
+  // RFC9460 section 7.3:
+  //   The presentation value SHALL be a comma-separated list (Appendix A.1)
+  //   of one or more IP addresses ...
+  SVC_PARAM("ipv4hint", 4u, MANDATORY_VALUE, parse_ipv4hint, parse_ipv4hint),
+  SVC_PARAM("ech", 5u, OPTIONAL_VALUE, parse_ech, parse_ech),
+  // RFC9460 section 7.3:
+  //   See "ipv4hint".
+  SVC_PARAM("ipv6hint", 6u, MANDATORY_VALUE, parse_ipv6hint, parse_ipv6hint),
   // RFC9461 section 5:
   //   If the "alpn" SvcParam indicates support for HTTP, "dohpath" MUST be
   //   present.
-  SVC_PARAM("dohpath", 7u, 2u, parse_dohpath, parse_dohpath_non_strict),
+  SVC_PARAM("dohpath", 7u, MANDATORY_VALUE, parse_dohpath, parse_dohpath),
   SVC_PARAM("ohttp", 8u, 0u, 0, 0),
 };
 
 static const svc_param_info_t unknown_svc_param =
-  SVC_PARAM("unknown", 0u, 2u, parse_unknown, parse_unknown);
+  SVC_PARAM("unknown", 0u, OPTIONAL_VALUE, parse_unknown, parse_unknown);
 
 #undef SVC_PARAM
 
@@ -498,18 +480,32 @@ static int32_t parse_mandatory(
   (void)param;
 
   // RFC9460 section 8:
-  //   The presentation value SHALL be a comma-seperatred list of one or more
-  //   valid SvcParamKeys, ...
-  bool has_mandatory = false;
+  //   This SvcParamKey is always automatically mandatory and MUST NOT appear
+  //   in its own value-list. Other automatically mandatory keys SHOULD NOT
+  //   appear in the list either.
+  uint64_t mandatory = (1u << SVC_PARAM_KEY_MANDATORY);
+  uint64_t keys = 0u;
   int32_t highest_key = -1;
   const char *data = token->data;
   uint8_t *whence = rdata->octets;
   size_t skip;
 
+  // RFC9460 section 9:
+  //   The "automatically mandatory" keys (Section 8) are "port" and
+  //   "no-default-alpn".
+  if (type->name.value == ZONE_HTTPS)
+    mandatory = (1u << SVC_PARAM_KEY_MANDATORY) |
+                (1u << SVC_PARAM_KEY_NO_DEFAULT_ALPN) |
+                (1u << SVC_PARAM_KEY_PORT);
+
+  // RFC9460 section 8:
+  //   The presentation value SHALL be a comma-seperatred list of one or more
+  //   valid SvcParamKeys, ...
   if (!(skip = scan_svc_param_key(data, &key)))
     SYNTAX_ERROR(parser, "Invalid mandatory in %s", NAME(type));
+  if (key < 64)
+    keys = 1llu << key;
 
-  has_mandatory = (key == 0);
   highest_key = key;
   key = htobe16(key);
   memcpy(rdata->octets, &key, sizeof(key));
@@ -520,8 +516,9 @@ static int32_t parse_mandatory(
     if (!(skip = scan_svc_param_key(data + 1, &key)))
       SYNTAX_ERROR(parser, "Invalid mandatory of %s", NAME(type));
 
-    // check if mandatory appears in mandatory key list
-    has_mandatory |= (key == 0);
+    // check if key appears in automatically mandatory key list
+    if (key < 64)
+      keys |= 1llu << key;
 
     data += skip + 1;
     if (key > highest_key) {
@@ -556,8 +553,8 @@ static int32_t parse_mandatory(
     }
   }
 
-  if (has_mandatory)
-    SEMANTIC_ERROR(parser, "Mandatory in mandatory of %s", NAME(type));
+  if (keys & mandatory)
+    SEMANTIC_ERROR(parser, "Automatically mandatory key(s) in mandatory of %s", NAME(type));
   if (rdata->octets >= rdata->limit)
     SYNTAX_ERROR(parser, "Invalid mandatory in %s", NAME(type));
   if (data != token->data + token->length)
@@ -565,29 +562,123 @@ static int32_t parse_mandatory(
   return 0;
 }
 
-nonnull((1,2,3,4,6))
+nonnull_all
+static int32_t parse_mandatory_lax(
+  parser_t *parser,
+  const type_info_t *type,
+  const rdata_info_t *field,
+  uint16_t key,
+  const svc_param_info_t *param,
+  rdata_t *rdata,
+  const token_t *token)
+{
+  (void)field;
+
+  // RFC9460 section 8:
+  //   This SvcParamKey is always automatically mandatory and MUST NOT appear
+  //   in its own value-list. Other automatically mandatory keys SHOULD NOT
+  //   appear in the list either.
+  uint64_t mandatory = (1u << SVC_PARAM_KEY_MANDATORY);
+  uint64_t keys = 0;
+  // RFC9460 section 8:
+  //   In wire format, the keys are represented by their numeric values in
+  //   network byte order, concatenated in strictly increasing numeric order.
+  //
+  // cannot reorder in secondary mode, print an error
+  bool out_of_order = false;
+  int32_t highest_key = -1;
+  const uint8_t *whence = rdata->octets;
+  const char *data = token->data;
+  size_t skip;
+
+  // RFC9460 section 8:
+  //   The presentation value SHALL be a comma-seperatred list of one or more
+  //   valid SvcParamKeys, ...
+  if (!(skip = scan_svc_param_key(data, &key)))
+    SYNTAX_ERROR(parser, "Invalid key in %s of %s", NAME(param), NAME(type));
+  if (key < 64)
+    keys |= 1llu << key;
+
+  // RFC9460 section 9:
+  //   The "automatically mandatory" keys (Section 8) are "port" and
+  //   "no-default-alpn".
+  if (type->name.value == ZONE_HTTPS)
+    mandatory = (1u << SVC_PARAM_KEY_MANDATORY) |
+                (1u << SVC_PARAM_KEY_NO_DEFAULT_ALPN) |
+                (1u << SVC_PARAM_KEY_PORT);
+
+  key = htobe16(key);
+  memcpy(rdata->octets, &key, 2);
+  rdata->octets += 2;
+  data += skip;
+
+  while (*data == ',' && rdata->octets < rdata->limit) {
+    if (!(skip = scan_svc_param_key(data + 1, &key)))
+      SYNTAX_ERROR(parser, "Invalid key in %s of %s", NAME(param), NAME(type));
+
+    // check if key appears in automatically mandatory key list
+    if (key < 64)
+      keys |= (1llu << key);
+
+    if ((int32_t)key <= highest_key) {
+      // RFC9460 section 8:
+      //   In wire format, the keys are represented by their numeric values in
+      //   network byte order, concatenated in ascending order.
+      const uint8_t *octets = whence;
+      uint16_t smaller_key = 0;
+      while (octets < rdata->octets) {
+        memcpy(&smaller_key, octets, sizeof(smaller_key));
+        smaller_key = be16toh(smaller_key);
+        if (key < smaller_key)
+          break;
+        octets += 2;
+      }
+      assert(octets <= rdata->octets);
+      // RFC9460 section 8:
+      //   Keys MAY appear in any order, but MUST NOT appear more than once.
+      if (key == smaller_key)
+        SEMANTIC_ERROR(parser, "Duplicate key in mandatory of %s", NAME(type));
+      assert(key < smaller_key);
+      out_of_order = true;
+    }
+
+    data += skip + 1;
+    key = htobe16(key);
+    memcpy(rdata->octets, &key, 2);
+    rdata->octets += 2;
+  }
+
+  if (keys & mandatory)
+    SEMANTIC_ERROR(parser, "Automatically mandatory key(s) in mandatory of %s", NAME(type));
+  if (out_of_order)
+    SEMANTIC_ERROR(parser, "Out of order keys in mandatory of %s", NAME(type));
+  if (rdata->octets >= rdata->limit - 2)
+    SYNTAX_ERROR(parser, "Invalid %s", NAME(type));
+  if (data != token->data + token->length)
+    SYNTAX_ERROR(parser, "Invalid %s", NAME(type));
+  return 0;
+}
+
+nonnull_all
 static really_inline int32_t check_mandatory(
   zone_parser_t *parser,
   const type_info_t *type,
   const rdata_info_t *field,
   const rdata_t *rdata,
-  const uint8_t *mandatory,
   const uint8_t *parameters)
 {
-  if (!mandatory)
-    return 0;
-  // parameters are guaranteed to be sorted in strict mode
-  assert(mandatory == parameters);
-  assert(!mandatory[0] && !mandatory[1]);
+  // parameters are guaranteed to be in order (automatic in strict mode)
+  if (parameters[0] || parameters[1])
+    return 0; // no mandatory parameter
 
   uint16_t length;
-  memcpy(&length, mandatory + 2, sizeof(length));
+  memcpy(&length, parameters + 2, sizeof(length));
   length = be16toh(length);
-  assert(rdata->octets - mandatory >= 4 + length);
+  assert(rdata->octets - parameters >= 4 + length);
 
   bool missing_keys = false;
-  const uint8_t *limit = mandatory + 4 + length;
-  const uint8_t *keys = mandatory + 4;
+  const uint8_t *limit = parameters + 4 + length;
+  const uint8_t *keys = parameters + 4;
   parameters += 4 + length;
 
   assert(parameters <= rdata->octets);
@@ -630,146 +721,45 @@ static really_inline int32_t check_mandatory(
   return 0;
 }
 
-nonnull_all
-static int32_t parse_mandatory_non_strict(
+nonnull((1, 2, 3, 5, 7))
+static really_inline int32_t parse_svc_param(
   parser_t *parser,
   const type_info_t *type,
   const rdata_info_t *field,
   uint16_t key,
   const svc_param_info_t *param,
+  const parse_svc_param_t parse,
   rdata_t *rdata,
   const token_t *token)
 {
-  (void)field;
-
-  // RFC9460 section 8:
-  //   The presentation value SHALL be a comma-seperatred list of one or more
-  //   valid SvcParamKeys, ...
-  bool has_mandatory = false;
-  // RFC9460 section 8:
-  //   In wire format, the keys are represented by their numeric values in
-  //   network byte order, concatenated in strictly increasing numeric order.
-  //
-  // cannot reorder in secondary mode, print an error
-  bool out_of_order = false;
-  int32_t highest_key = -1;
-  const uint8_t *whence = rdata->octets;
-  const char *data = token->data;
-  size_t skip;
-
-  if (!(skip = scan_svc_param_key(data, &key)))
-    SYNTAX_ERROR(parser, "Invalid key in %s of %s", NAME(param), NAME(type));
-  has_mandatory = (key == 0);
-  key = htobe16(key);
-  memcpy(rdata->octets, &key, 2);
-  rdata->octets += 2;
-  data += skip;
-
-  while (*data == ',' && rdata->octets < rdata->limit) {
-    if (!(skip = scan_svc_param_key(data + 1, &key)))
-      SYNTAX_ERROR(parser, "Invalid key in %s of %s", NAME(param), NAME(type));
-
-    // check if mandatory appears in mandatory key list
-    has_mandatory |= (key == 0);
-
-    if ((int32_t)key <= highest_key) {
-      // RFC9460 section 8:
-      //   In wire format, the keys are represented by their numeric values in
-      //   network byte order, concatenated in ascending order.
-      const uint8_t *octets = whence;
-      uint16_t smaller_key = 0;
-      while (octets < rdata->octets) {
-        memcpy(&smaller_key, octets, sizeof(smaller_key));
-        smaller_key = be16toh(smaller_key);
-        if (key < smaller_key)
-          break;
-        octets += 2;
-      }
-      assert(octets <= rdata->octets);
-      // RFC9460 section 8:
-      //   Keys MAY appear in any order, but MUST NOT appear more than once.
-      if (key == smaller_key)
-        SEMANTIC_ERROR(parser, "Duplicate key in mandatory of %s", NAME(type));
-      assert(key < smaller_key);
-      out_of_order = true;
-    }
-
-    data += skip + 1;
-    key = htobe16(key);
-    memcpy(rdata->octets, &key, 2);
-    rdata->octets += 2;
+  switch ((token != NULL) | param->has_value) {
+    case 0: // void parameter without value
+      return 0;
+    case 1: // void parameter with value
+      SEMANTIC_ERROR(parser, "%s with value in %s", NAME(field), NAME(type));
+      if (unlikely(!token->length))
+        return 0;
+      break;
+    case 2: // parameter without optional value
+      return 0;
+    case 3: // parameter with optional value
+      if (unlikely(!token->length))
+        return 0;
+      break;
+    case 4: // parameter without value
+      SEMANTIC_ERROR(parser, "%s without value in %s", NAME(field), NAME(type));
+      return 0;
+    case 5: // parameter with value
+      if (unlikely(!token->length))
+        SEMANTIC_ERROR(parser, "%s without value in %s", NAME(field), NAME(type));
+      break;
   }
 
-  if (has_mandatory)
-    SEMANTIC_ERROR(parser, "Mandatory in mandatory of %s", NAME(type));
-  if (out_of_order)
-    SEMANTIC_ERROR(parser, "Out of order keys in mandatory of %s", NAME(type));
-  if (rdata->octets >= rdata->limit - 2)
-    SYNTAX_ERROR(parser, "Invalid %s", NAME(type));
-  if (data != token->data + token->length)
-    SYNTAX_ERROR(parser, "Invalid %s", NAME(type));
-  return 0;
-}
-
-nonnull((1,2,3,4,6))
-static really_inline int32_t check_mandatory_non_strict(
-  zone_parser_t *parser,
-  const type_info_t *type,
-  const rdata_info_t *field,
-  const rdata_t *rdata,
-  const uint8_t *mandatory,
-  const uint8_t *parameters)
-{
-  if (!mandatory || parameters == rdata->octets)
-    return 0;
-  assert(mandatory < rdata->octets);
-  assert(rdata->octets - mandatory >= 4);
-
-  uint16_t length;
-  memcpy(&length, mandatory + 2, sizeof(length));
-  length = be16toh(length);
-  assert(rdata->octets - mandatory >= 4 + length);
-
-  bool missing_keys = false;
-  const uint8_t *limit = mandatory + 4 + length;
-  const uint8_t *keys = mandatory + 4;
-
-  for (; !missing_keys && keys < limit; keys += 2) {
-    uint16_t key;
-    memcpy(&key, keys, sizeof(key));
-    // no byteswap, compare big endian
-
-    // mandatory is guaranteed to exist
-    if (!key)
-      continue;
-    // cannot shift parameters as parameters are not sorted and mandatory may
-    // contain duplicate keys in non-strict mode
-    assert(rdata->octets - parameters >= 4);
-    if (memcmp(parameters, &key, 2) == 0)
-      continue;
-    memcpy(&length, parameters + 2, 2);
-    length = be16toh(length);
-    assert(rdata->octets - parameters >= 4 + length);
-    const uint8_t *parameter = parameters + 4 + length;
-    while (parameter < rdata->octets) {
-      if (memcmp(parameter, &key, 2) == 0)
-        break;
-      memcpy(&length, parameter + 2, 2);
-      length = be16toh(length);
-      assert(rdata->octets - parameters >= 4 + length);
-      parameter += 4 + length;
-    }
-
-    missing_keys = (parameter == rdata->octets);
-  }
-
-  if (missing_keys)
-    SEMANTIC_ERROR(parser, "Mandatory %s missing in %s", NAME(field), NAME(type));
-  return 0;
+  return parse(parser, type, field, key, param, rdata, token);
 }
 
 nonnull_all
-static int32_t parse_svc_params_non_strict(
+static int32_t parse_svc_params_lax(
   parser_t *parser,
   const type_info_t *type,
   const rdata_info_t *field,
@@ -778,91 +768,73 @@ static int32_t parse_svc_params_non_strict(
 {
   bool out_of_order = false;
   int32_t code, highest_key = -1;
-  const uint16_t zero = 0;
+  uint32_t errors = 0;
   const uint8_t *whence = rdata->octets;
-  const uint8_t *mandatory = NULL;
+  uint64_t keys = 0;
 
+  // FIXME: check if parameter even fits
   while (is_contiguous(token)) {
-    size_t skip;
+    size_t count;
     uint16_t key;
     const svc_param_info_t *param;
+    const token_t *value = token;
 
-    if (!(skip = scan_svc_param(token->data, &key, &param)))
+    if (!(count = scan_svc_param(token->data, &key, &param)))
       SYNTAX_ERROR(parser, "Invalid %s in %s", NAME(field), NAME(type));
     assert(param);
 
-    if ((int32_t)key <= highest_key) {
-      const uint8_t *octets = whence;
-      uint16_t smaller_key = 65535;
+    if (likely(key > highest_key))
+      highest_key = key;
+    else
       out_of_order = true;
 
-      while (octets < rdata->octets) {
-        memcpy(&smaller_key, octets, sizeof(smaller_key));
-        smaller_key = be16toh(smaller_key);
-        if (key <= smaller_key)
-          break;
-        uint16_t length;
-        memcpy(&length, octets + 2, sizeof(length));
-        length = be16toh(length);
-        octets += length + 4;
-      }
+    if (key < 64)
+      keys |= (1llu << key);
 
-      assert(octets < rdata->octets);
-      if (key == smaller_key)
-        SEMANTIC_ERROR(parser, "Duplicate key in %s", NAME(type));
-    }
+    if (token->data[count] != '=')
+      value = NULL;
+    else if (token->data[count+1] != '"')
+      (void)(token->data += count + 1), token->length -= count + 1;
+    else if ((code = take_quoted(parser, type, field, token)) < 0)
+      return code;
 
-    switch ((token->data[skip] == '=') | param->has_value) {
-      case 2: // parameter without value
-        SEMANTIC_ERROR(parser, "%s without value in %s",
-                               NAME(field), NAME(type));
-        // fall through
-      case 0: // void parameter without value
-        key = htobe16(key);
-        memcpy(rdata->octets, &key, sizeof(key));
-        memcpy(rdata->octets+2, &zero, sizeof(zero));
-        if (!key && !mandatory)
-          mandatory = rdata->octets;
-        rdata->octets += 4;
-        break;
-      case 1: // void parameter with value
-        SEMANTIC_ERROR(parser, "%s with value in %s",
-                               NAME(field), NAME(type));
-        // fall through
-      case 3: // parameter with value
-        skip += 1;
-        // quoted value, separate token
-        if (token->data[skip] != '"')
-          (void)(token->data += skip), token->length -= skip;
-        else if ((code = take_quoted(parser, type, field, token)) < 0)
-          return 0;
-        {
-          uint8_t *octets = rdata->octets;
-          rdata->octets += 4;
-          if ((token->length) &&
-              (code = param->parse_non_strict(parser, type, field, key, param, rdata, token)))
-            return code;
-          uint16_t length = (uint16_t)(rdata->octets - octets) - 4;
-          key = htobe16(key);
-          length = htobe16(length);
-          memcpy(octets, &key, sizeof(key));
-          memcpy(octets+2, &length, sizeof(length));
-          if (!key && !mandatory)
-            mandatory = octets;
-        }
-        break;
-    }
+    uint8_t *octets = rdata->octets;
+    uint16_t length;
+    rdata->octets += 4;
+    if ((code = parse_svc_param(
+         parser, type, field, key, param, param->parse_lax, rdata, value)) < 0)
+      return code;
 
+    errors += (code != 0);
+    key = htobe16(key);
+    memcpy(octets, &key, sizeof(key));
+    assert(rdata->octets >= octets && (rdata->octets - octets) <= 65535 + 4);
+    length = (uint16_t)((rdata->octets - octets) - 4);
+    length = htobe16(length);
+    memcpy(octets + 2, &length, sizeof(length));
     take(parser, token);
   }
 
-  if (out_of_order)
-    SEMANTIC_ERROR(parser, "Out of order %s(s) in %s", NAME(field), NAME(type));
-  if ((code = have_delimiter(parser, type, token)))
-    return code;
-  if ((code = check_mandatory_non_strict(parser, type, field, rdata, mandatory, whence)))
-    return code;
-  return 0;
+  if (likely(errors == 0 && whence != rdata->octets)) {
+    assert(whence <= rdata->octets + 4);
+
+    if (unlikely(out_of_order)) {
+      SEMANTIC_ERROR(parser, "Out of order %s in %s", NAME(field), NAME(type));
+    } else { // warn about missing or out-of-order parameters
+      if (keys & 0x01)
+        check_mandatory(parser, type, field, rdata, whence);
+      // RFC9460 section 7.2:
+      //   For "no-default-alpn", the presentation and wire-format values MUST
+      //   be empty. When "no-default-alpn" is specified in an RR, "alpn" must
+      //   also be specified in order for the RR to be "self-consistent"
+      //   (Section 2.4.3).
+      if ((keys & 0x04) && !(keys & 0x02))
+        SEMANTIC_ERROR(parser, "%s with no-default-alpn but without alpn in %s",
+                       NAME(field), NAME(type));
+    }
+  }
+
+  return have_delimiter(parser, type, token);
 }
 
 // https://www.iana.org/assignments/dns-svcb/dns-svcb.xhtml
@@ -876,70 +848,55 @@ static really_inline int32_t parse_svc_params(
 {
   // propagate data as-is if secondary
   if (parser->options.non_strict)
-    return parse_svc_params_non_strict(parser, type, field, rdata, token);
+    return parse_svc_params_lax(parser, type, field, rdata, token);
 
-  const uint16_t zero = 0;
-  int32_t code, highest_key = -1;
+  int32_t code;
+  int32_t highest_key = -1;
   uint8_t *whence = rdata->octets;
+  uint64_t keys = 0;
 
   while (is_contiguous(token)) {
-    size_t skip;
+    size_t count;
     uint16_t key;
+    const token_t *value = token;
     const svc_param_info_t *param;
 
-    if (!(skip = scan_svc_param(token->data, &key, &param)))
+    if (!(count = scan_svc_param(token->data, &key, &param)))
       SYNTAX_ERROR(parser, "Invalid %s in %s", NAME(field), NAME(type));
     assert(param);
 
-    if (key > highest_key) {
-      highest_key = key;
+    if (key < 64)
+      keys |= (1llu << key);
 
-      switch ((token->data[skip] == '=') | param->has_value) {
-        case 2: // parameter without optional value
-          SEMANTIC_ERROR(parser, "%s without value in %s",
-                                 NAME(field), NAME(type));
-          // fall through
-        case 0: // void parameter without value
-          key = htobe16(key);
-          memcpy(rdata->octets, &key, sizeof(key));
-          memcpy(rdata->octets+2, &zero, sizeof(zero));
-          rdata->octets += 4;
-          break;
-        case 1: // void parameter with value
-          SEMANTIC_ERROR(parser, "%s with value in %s",
-                                 NAME(field), NAME(type));
-          // fall through
-        case 3: // parameter with value
-          skip += 1;
-          // quoted parameter, separate token
-          if (token->data[skip] != '"')
-            (void)(token->data += skip), token->length -= skip;
-          else if ((code = take_quoted(parser, type, field, token)) < 0)
-            return code;
-          {
-            uint8_t *octets = rdata->octets;
-            rdata->octets += 4;
-            if ((token->length) &&
-                (code = param->parse(parser, type, field, key, param, rdata, token)))
-              return code;
-            uint16_t length = (uint16_t)(rdata->octets - octets) - 4;
-            key = htobe16(key);
-            length = htobe16(length);
-            memcpy(octets, &key, sizeof(key));
-            memcpy(octets+2, &length, sizeof(length));
-          }
-          break;
-      }
+    if (token->data[count] != '=')
+      value = NULL;
+    else if (token->data[count+1] != '"')
+      (void)(token->data += count + 1), token->length -= count + 1;
+    else if ((code = take_quoted(parser, type, field, token)) < 0)
+      return code;
+
+    uint8_t *octets;
+    uint16_t length;
+
+    if (likely(key > highest_key)) {
+      highest_key = key;
+      octets = rdata->octets;
+      rdata->octets += 4;
+      if ((code = parse_svc_param(
+           parser, type, field, key, param, param->parse, rdata, value)))
+        return code;
+      assert(rdata->octets >= octets && (rdata->octets - octets) <= 65535 + 4);
+      length = (uint16_t)((rdata->octets - octets) - 4);
     } else {
-      uint8_t *octets = whence;
+      octets = whence;
       uint16_t smaller_key = 65535;
 
+      // this can probably be done in a function or something
       while (octets < rdata->octets) {
         memcpy(&smaller_key, octets, sizeof(smaller_key));
         smaller_key = be16toh(smaller_key);
         if (key <= smaller_key)
           break;
-        uint16_t length;
         memcpy(&length, octets + 2, sizeof(length));
         length = be16toh(length);
         octets += length + 4;
@@ -949,69 +906,50 @@ static really_inline int32_t parse_svc_params(
       if (key == smaller_key)
         SEMANTIC_ERROR(parser, "Duplicate key in %s", NAME(type));
 
-      switch ((token->data[skip] == '=') | param->has_value) {
-        case 2: // parameter without value
-          SEMANTIC_ERROR(parser, "%s without value in %s",
-                                 NAME(field), NAME(type));
-          // fall through
-        case 0: // void parameter without value
-          key = htobe16(key);
-          memmove(octets + 4, octets, (uintptr_t)rdata->octets - (uintptr_t)octets);
-          memcpy(octets, &key, sizeof(key));
-          memcpy(octets+2, &zero, sizeof(zero));
-          rdata->octets += 4;
-          break;
-        case 1: // void parameter with value
-          SEMANTIC_ERROR(parser, "%s with value in %s",
-                                 NAME(field), NAME(type));
-          // fall through
-        case 3: // parameter with value
-          skip += 1;
-          // quoted parameter, separate token
-          if (token->data[skip] != '"')
-            (void)(token->data += skip), token->length -= skip;
-          else if ((code = take_quoted(parser, type, field, token)) < 0)
-            return code;
-          {
-            uint16_t length;
-            rdata_t param_rdata;
-            // RFC9460 section 2.2:
-            //   SvcParamKeys SHALL appear in increasing numeric order.
-            //
-            // move existing data to end of the buffer and reset limit to
-            // avoid allocating memory
-            assert(rdata->octets - octets < ZONE_RDATA_SIZE);
-            length = (uint16_t)(rdata->octets - octets);
-            param_rdata.octets = octets + 4u;
-            param_rdata.limit = parser->rdata->octets + (ZONE_RDATA_SIZE - length);
-            // move data PADDING_SIZE past limit to ensure SIMD operatations
-            // do not overwrite existing data
-            memmove(param_rdata.limit + ZONE_PADDING_SIZE, octets, length);
-            if ((token->length) &&
-                (code = param->parse(parser, type, field, key, param, &param_rdata, token)))
-              return code;
-            assert(param_rdata.octets < param_rdata.limit);
-            memmove(param_rdata.octets, param_rdata.limit + ZONE_PADDING_SIZE, length);
-            rdata->octets = param_rdata.octets + length;
-            length = (uint16_t)(param_rdata.octets - octets) - 4u;
-            key = htobe16(key);
-            length = htobe16(length);
-            memcpy(octets, &key, sizeof(key));
-            memcpy(octets+2, &length, sizeof(length));
-          }
-          break;
-      }
+      rdata_t rdata_view;
+      // RFC9460 section 2.2:
+      //   SvcParamKeys SHALL appear in increasing numeric order.
+      //
+      // move existing data to end of the buffer and reset limit to
+      // avoid allocating memory
+      assert(rdata->octets - octets < ZONE_RDATA_SIZE);
+      length = (uint16_t)(rdata->octets - octets);
+      rdata_view.octets = octets + 4u;
+      rdata_view.limit = parser->rdata->octets + (ZONE_RDATA_SIZE - length);
+      // move data PADDING_SIZE past limit to ensure SIMD operatations
+      // do not overwrite existing data
+      memmove(rdata_view.limit + ZONE_PADDING_SIZE, octets, length);
+      if ((code = parse_svc_param(
+           parser, type, field, key, param, param->parse, &rdata_view, token)))
+        return code;
+      assert(rdata_view.octets < rdata_view.limit);
+      memmove(rdata_view.octets, rdata_view.limit + ZONE_PADDING_SIZE, length);
+      rdata->octets = rdata_view.octets + length;
+      length = (uint16_t)(rdata_view.octets - octets) - 4u;
     }
 
+    key = htobe16(key);
+    memcpy(octets, &key, sizeof(key));
+    length = htobe16(length);
+    memcpy(octets + 2, &length, sizeof(length));
     take(parser, token);
   }
 
   if ((code = have_delimiter(parser, type, token)))
     return code;
-  if (whence == rdata->octets || memcmp(whence, &zero, sizeof(zero)) != 0)
-    return 0;
   assert(whence);
-  return check_mandatory(parser, type, field, rdata, whence, whence);
+  if ((keys & (1u << SVC_PARAM_KEY_MANDATORY)) &&
+      (code = check_mandatory(parser, type, field, rdata, whence)) < 0)
+    return code;
+  // RFC9460 section 7.2:
+  //   For "no-default-alpn", the presentation and wire-format values MUST be
+  //   empty. When "no-default-alpn" is specified in an RR, "alpn" must also
+  //   be specified in order for the RR to be "self-consistent"
+  //   (Section 2.4.3).
+  if ((keys & 0x04) && !(keys & 0x02))
+    SEMANTIC_ERROR(parser, "%s with no-default-alpn but without alpn in %s",
+                   NAME(field), NAME(type));
+  return 0;
 }
 
 #endif // SVCB_H

--- a/src/generic/types.h
+++ b/src/generic/types.h
@@ -72,6 +72,8 @@ static really_inline int32_t parse_text(
 typedef SSIZE_T ssize_t;
 #endif
 
+// FIXME: check functions can be simplified as int32_t is wide enough to
+//        represent errors and the maximum length of rdata.
 nonnull((1,2,3,4))
 static really_inline ssize_t check_bytes(
   parser_t *parser,
@@ -2061,7 +2063,17 @@ nonnull_all
 static int32_t check_svcb_rr(
   parser_t *parser, const type_info_t *type, const rdata_t *rdata)
 {
+  //
   // FIXME: implement checking parameters etc
+  //
+  // - check if all keys in mandatory exist
+  // - check if at least keys and key lengths are valid
+  //
+  // FIXME: implement reordering parameters in strict (primary) mode
+  // FIXME: note that when reordering or checking, rdata may not actually
+  //        contain valid parameters
+  //
+
   return accept_rr(parser, type, rdata);
 }
 
@@ -2091,6 +2103,10 @@ nonnull_all
 static int32_t check_https_rr(
   parser_t *parser, const type_info_t *type, const rdata_t *rdata)
 {
+  //
+  // FIXME: incorporate fixes mentioned in check_svcb_rr
+  //
+
   return accept_rr(parser, type, rdata);
 }
 

--- a/tests/svcb.c
+++ b/tests/svcb.c
@@ -10,11 +10,6 @@
 #include <setjmp.h>
 #include <string.h>
 #include <cmocka.h>
-#if _WIN32
-#include <winsock2.h>
-#else
-#include <netinet/in.h>
-#endif
 
 #include "zone.h"
 
@@ -46,8 +41,20 @@ struct rdata {
 // D.1. AliasMode
 
 // Figure 2: AliasMode
-static const char d1_text[] =
-  PAD("example.com.   HTTPS   0 foo.example.com.");
+static const char d1_svcb_text[] =
+  PAD("v01     SVCB    0 foo.example.com.");
+static const char d1_svcb_generic_text[] =
+  PAD("v01     SVCB    \\# 19 (\n"
+      "00 00                                              ; priority\n"
+      "03 66 6f 6f 07 65 78 61 6d 70 6c 65 03 63 6f 6d 00 ; target\n"
+      ")");
+static const char d1_https_text[] =
+  PAD("v11     HTTPS   0 foo.example.com.");
+static const char d1_https_generic_text[] =
+  PAD("v11     HTTPS   \\# 19 (\n"
+      "00 00                                              ; priority\n"
+      "03 66 6f 6f 07 65 78 61 6d 70 6c 65 03 63 6f 6d 00 ; target\n"
+      ")");
 static const rdata_t d1_rdata = RDATA(
   // priority
   0x00, 0x00,
@@ -60,8 +67,23 @@ static const rdata_t d1_rdata = RDATA(
 // D.2. ServiceMode
 
 // Figure 3: TargetName is "."
-static const char d2_f3_text[] =
-  PAD("example.com.   SVCB   1 .");
+// The first form is the simple "use the ownername".
+static const char d2_f3_svcb_text[] =
+  PAD("v02     SVCB    1 .");
+static const char d2_f3_svcb_generic_text[] =
+  PAD("v02     SVCB    \\# 3 (\n"
+      "00 01      ; priority\n"
+      "00         ; target (root label)\n"
+      ")");
+
+static const char d2_f3_https_text[] =
+  PAD("v12     HTTPS   1 .");
+static const char d2_f3_https_generic_text[] =
+  PAD("v12     HTTPS   \\# 3 (\n"
+      "00 01      ; priority\n"
+      "00         ; target (root label)\n"
+      ")");
+
 static const rdata_t d2_f3_rdata = RDATA(
   // priority
   0x00, 0x01,
@@ -69,8 +91,29 @@ static const rdata_t d2_f3_rdata = RDATA(
   0x00);
 
 // Figure 4: Specifies a Port
-static const char d2_f4_text[] =
-  PAD("example.com.   SVCB   16 foo.example.com. port=53");
+// This vector only has a port.
+static const char d2_f4_svcb_text[] =
+  PAD("v03     SVCB    16 foo.example.com. port=53");
+static const char d2_f4_svcb_generic_text[] =
+  PAD("v03     SVCB    \\# 25 (\n"
+      "00 10                                              ; priority\n"
+      "03 66 6f 6f 07 65 78 61 6d 70 6c 65 03 63 6f 6d 00 ; target\n"
+      "00 03                                              ; key 3\n"
+      "00 02                                              ; length 2\n"
+      "00 35                                              ; value\n"
+      ")");
+
+static const char d2_f4_https_text[] =
+  PAD("v13     HTTPS   16 foo.example.com. port=53");
+static const char d2_f4_https_generic_text[] =
+  PAD("v13     HTTPS   \\# 25 (\n"
+      "00 10                                              ; priority\n"
+      "03 66 6f 6f 07 65 78 61 6d 70 6c 65 03 63 6f 6d 00 ; target\n"
+      "00 03                                              ; key 3\n"
+      "00 02                                              ; length 2\n"
+      "00 35                                              ; value\n"
+      ")");
+
 static const rdata_t d2_f4_rdata = RDATA(
   // priority
   0x00, 0x10,
@@ -86,8 +129,29 @@ static const rdata_t d2_f4_rdata = RDATA(
   0x00, 0x35);
 
 // Figure 5: A Generic Key and Unquoted Value
-static const char d2_f5_text[] =
-  PAD("example.com.   SVCB   1 foo.example.com. key667=hello");
+// This example has a key that is not registered, its value is unquoted.
+static const char d2_f5_svcb_text[] =
+  PAD("v04     SVCB    1 foo.example.com. key667=hello");
+static const char d2_f5_svcb_generic_text[] =
+  PAD("v04     SVCB    \\# 28 (\n"
+      "00 01                                              ; priority\n"
+      "03 66 6f 6f 07 65 78 61 6d 70 6c 65 03 63 6f 6d 00 ; target\n"
+      "02 9b                                              ; key 667\n"
+      "00 05                                              ; length 5\n"
+      "68 65 6c 6c 6f                                     ; value\n"
+      ")");
+
+static const char d2_f5_https_text[] =
+  PAD("v14     HTTPS   1 foo.example.com. key667=hello");
+static const char d2_f5_https_generic_text[] =
+  PAD("v14     HTTPS   \\# 28 (\n"
+      "00 01                                              ; priority\n"
+      "03 66 6f 6f 07 65 78 61 6d 70 6c 65 03 63 6f 6d 00 ; target\n"
+      "02 9b                                              ; key 667\n"
+      "00 05                                              ; length 5\n"
+      "68 65 6c 6c 6f                                     ; value\n"
+      ")");
+
 static const rdata_t d2_f5_rdata = RDATA(
   // priority
   0x00, 0x01,
@@ -103,8 +167,30 @@ static const rdata_t d2_f5_rdata = RDATA(
   0x68, 0x65, 0x6c, 0x6c, 0x6f);
 
 // Figure 6: A Generic Key and Quoted Value with a Decimal Escape
-static const char d2_f6_text[] =
-  PAD("example.com.   SVCB   1 foo.example.com. key667=\"hello\\210qoo\"");
+// This example has a key that is not registered, its value is quoted and
+// contains a decimal-escaped character.
+static const char d2_f6_svcb_text[] =
+  PAD("v05     SVCB    1 foo.example.com. key667=\"hello\\210qoo\"");
+static const char d2_f6_svcb_generic_text[] =
+  PAD("v05     SVCB    \\# 32 (\n"
+      "00 01                                              ; priority\n"
+      "03 66 6f 6f 07 65 78 61 6d 70 6c 65 03 63 6f 6d 00 ; target\n"
+      "02 9b                                              ; key 667\n"
+      "00 09                                              ; length 9\n"
+      "68 65 6c 6c 6f d2 71 6f 6f                         ; value\n"
+      ")");
+
+static const char d2_f6_https_text[] =
+  PAD("v15     HTTPS   1 foo.example.com. key667=\"hello\\210qoo\"");
+static const char d2_f6_https_generic_text[] =
+  PAD("v15     HTTPS   \\# 32 (\n"
+      "00 01                                              ; priority\n"
+      "03 66 6f 6f 07 65 78 61 6d 70 6c 65 03 63 6f 6d 00 ; target\n"
+      "02 9b                                              ; key 667\n"
+      "00 09                                              ; length 9\n"
+      "68 65 6c 6c 6f d2 71 6f 6f                         ; value\n"
+      ")");
+
 static const rdata_t d2_f6_rdata = RDATA(
   // priority
   0x00, 0x01,
@@ -121,10 +207,31 @@ static const rdata_t d2_f6_rdata = RDATA(
   0x6f);
 
 // Figure 7: Two Quoted IPv6 Hints
-static const char d2_f7_text[] =
-  PAD("example.com.   SVCB   1 foo.example.com. (\n"
-      "                        ipv6hint=\"2001:db8::1,2001:db8::53:1\"\n"
-      "                        )\n");
+// Here, two IPv6 hints are quoted in the presentation format.
+static const char d2_f7_svcb_text[] =
+  PAD("v06     SVCB    1 foo.example.com. ipv6hint=\"2001:db8::1,2001:db8::53:1\"");
+static const char d2_f7_svcb_generic_text[] =
+  PAD("v06     SVCB    \\# 55 (\n"
+      "00 01                                              ; priority\n"
+      "03 66 6f 6f 07 65 78 61 6d 70 6c 65 03 63 6f 6d 00 ; target\n"
+      "00 06                                              ; key 6\n"
+      "00 20                                              ; length 32\n"
+      "20 01 0d b8 00 00 00 00 00 00 00 00 00 00 00 01    ; first address\n"
+      "20 01 0d b8 00 00 00 00 00 00 00 00 00 53 00 01    ; second address\n"
+      ")");
+
+static const char d2_f7_https_text[] =
+  PAD("v16     HTTPS   1 foo.example.com. ipv6hint=\"2001:db8::1,2001:db8::53:1\"");
+static const char d2_f7_https_generic_text[] =
+  PAD("v16     HTTPS   \\# 55 (\n"
+      "00 01                                              ; priority\n"
+      "03 66 6f 6f 07 65 78 61 6d 70 6c 65 03 63 6f 6d 00 ; target\n"
+      "00 06                                              ; key 6\n"
+      "00 20                                              ; length 32\n"
+      "20 01 0d b8 00 00 00 00 00 00 00 00 00 00 00 01    ; first address\n"
+      "20 01 0d b8 00 00 00 00 00 00 00 00 00 53 00 01    ; second address\n"
+      ")");
+
 static const rdata_t d2_f7_rdata = RDATA(
   // priority
   0x00, 0x01,
@@ -144,10 +251,33 @@ static const rdata_t d2_f7_rdata = RDATA(
   0x00, 0x00, 0x00, 0x00, 0x00, 0x53, 0x00, 0x01);
 
 // Figure 8: An IPv6 Hint Using the Embedded IPv4 Syntax
-static const char d2_f8_text[] =
-  PAD("example.com.   SVCB   1 example.com. (\n"
-      "                        ipv6hint=\"2001:db8:122:344::192.0.2.33\"\n"
-      "                        )");
+// This example shows a single IPv6 hint in IPv4 mapped IPv6 presentation format.
+static const char d2_f8_svcb_text[] =
+  PAD("v07     SVCB    1 example.com. (\n"
+      "          ipv6hint=\"2001:db8:ffff:ffff:ffff:ffff:198.51.100.100\"\n"
+      ")");
+static const char d2_f8_svcb_generic_text[] =
+  PAD("v07     SVCB    \\# 35 (\n"
+      "00 01                                              ; priority\n"
+      "07 65 78 61 6d 70 6c 65 03 63 6f 6d 00             ; target\n"
+      "00 06                                              ; key 6\n"
+      "00 10                                              ; length 16\n"
+      "20 01 0d b8 ff ff ff ff ff ff ff ff c6 33 64 64    ; address\n"
+      ")");
+
+static const char d2_f8_https_text[] =
+  PAD("v17     HTTPS   1 example.com. (\n"
+      "          ipv6hint=\"2001:db8:ffff:ffff:ffff:ffff:198.51.100.100\"\n"
+      ")");
+static const char d2_f8_https_generic_text[] =
+  PAD("v17     HTTPS   \\# 35 (\n"
+      "00 01                                              ; priority\n"
+      "07 65 78 61 6d 70 6c 65 03 63 6f 6d 00             ; target\n"
+      "00 06                                              ; key 6\n"
+      "00 10                                              ; length 16\n"
+      "20 01 0d b8 ff ff ff ff ff ff ff ff c6 33 64 64    ; address\n"
+      ")");
+
 static const rdata_t d2_f8_rdata = RDATA(
   // priority
   0x00, 0x01,
@@ -159,15 +289,59 @@ static const rdata_t d2_f8_rdata = RDATA(
   // length 16
   0x00, 0x10,
   // address
-  0x20, 0x01, 0x0d, 0xb8, 0x01, 0x22, 0x03, 0x44,
-  0x00, 0x00, 0x00, 0x00, 0xc0, 0x00, 0x02, 0x21);
+  0x20, 0x01, 0x0d, 0xb8, 0xff, 0xff, 0xff, 0xff,
+  0xff, 0xff, 0xff, 0xff, 0xc6, 0x33, 0x64, 0x64);
 
 // Figure 9: SvcParamKey Ordering Is Arbitrary in Presentation Format but Sorted in Wire Format
-static const char d2_f9_text[] =
-  PAD("example.com.   SVCB   16 foo.example.org. (\n"
-      "                         alpn=h2,h3-19 mandatory=ipv4hint,alpn\n"
-      "                         ipv4hint=192.0.2.1\n"
-      "                         )");
+// In the next vector, neither the SvcParamValues nor the mandatory keys are
+// sorted in presentation format, but are correctly sorted in the wire-format.
+static const char d2_f9_svcb_text[] =
+  PAD("v08     SVCB    16 foo.example.org. (\n"
+      "                   alpn=h2,h3-19 mandatory=ipv4hint,alpn\n"
+      "                   ipv4hint=192.0.2.1\n"
+      ")");
+static const char d2_f9_svcb_generic_text[] =
+  PAD("v08     SVCB    \\# 48 (\n"
+      "00 10                                              ; priority\n"
+      "03 66 6f 6f 07 65 78 61 6d 70 6c 65 03 6f 72 67 00 ; target\n"
+      "00 00                                              ; key 0\n"
+      "00 04                                              ; param length 4\n"
+      "00 01                                              ; value: key 1\n"
+      "00 04                                              ; value: key 4\n"
+      "00 01                                              ; key 1\n"
+      "00 09                                              ; param length 9\n"
+      "02                                                 ; alpn length 2\n"
+      "68 32                                              ; alpn value\n"
+      "05                                                 ; alpn length 5\n"
+      "68 33 2d 31 39                                     ; alpn value\n"
+      "00 04                                              ; key 4\n"
+      "00 04                                              ; param length 4\n"
+      "c0 00 02 01                                        ; param value\n"
+      ")");
+
+static const char d2_f9_https_text[] =
+  PAD("v18     HTTPS   16 foo.example.org. (\n"
+      "                   alpn=h2,h3-19 mandatory=ipv4hint,alpn\n"
+      "                   ipv4hint=192.0.2.1\n"
+      ")");
+static const char d2_f9_https_generic_text[] =
+  PAD("v18     HTTPS   \\# 48 (\n"
+      "00 10                                              ; priority\n"
+      "03 66 6f 6f 07 65 78 61 6d 70 6c 65 03 6f 72 67 00 ; target\n"
+      "00 00                                              ; key 0\n"
+      "00 04                                              ; param length 4\n"
+      "00 01                                              ; value: key 1\n"
+      "00 04                                              ; value: key 4\n"
+      "00 01                                              ; key 1\n"
+      "00 09                                              ; param length 9\n"
+      "02                                                 ; alpn length 2\n"
+      "68 32                                              ; alpn value\n"
+      "05                                                 ; alpn length 5\n"
+      "68 33 2d 31 39                                     ; alpn value\n"
+      "00 04                                              ; key 4\n"
+      "00 04                                              ; param length 4\n"
+      "c0 00 02 01                                        ; param value\n"
+      ")");
 
 static const rdata_t d2_f9_rdata = RDATA(
   // priority
@@ -202,19 +376,65 @@ static const rdata_t d2_f9_rdata = RDATA(
   0x00, 0x04,
   // param value
   0xc0, 0x00, 0x02, 0x01);
-
 #if 0
-// No Application-Layer Protocol Negotiation (ALPN) protocol identifiers that
-// contain a "\" (backslash) exist. To simplify parsing, in accordance with
-// RFC9460 appendix A.1, simdzone prohibits item lists containing backslashes
-// (for now).
-//
 // Figure 10: An "alpn" Value with an Escaped Comma and an Escaped Backslash in Two Presentation Formats
-static const char d2_f10_1_text[] =
-  PAD("example.com.   SVCB   16 foo.example.org. alpn=\"f\\\\oo\\,bar,h2\"");
+// This last (two) vectors has an alpn value with an escaped comma and an
+// escaped backslash in two presentation formats.
+static const char d2_f10_1_svcb_text[] =
+  PAD("v09     SVCB    16 foo.example.org. alpn=\"f\\\\oo\\,bar,h2\"");
+static const char d2_f10_1_svcb_generic_text[] =
+  PAD("v09     SVCB    \\# 35 (\n"
+      "00 10                                              ; priority\n"
+      "03 66 6f 6f 07 65 78 61 6d 70 6c 65 03 6f 72 67 00 ; target\n"
+      "00 01                                              ; key 1\n"
+      "00 0c                                              ; param length 12\n"
+      "08                                                 ; alpn length 8\n"
+      "66 5c 6f 6f 2c 62 61 72                            ; alpn value\n"
+      "02                                                 ; alpn length 2\n"
+      "68 32                                              ; alpn value\n"
+      ")");
 
-static const char d2_f10_2_text[] =
-  PAD("example.com.   SVCB   16 foo.example.org. alpn=f\\\092oo\092,bar,h2");
+static const char d2_f10_1_https_text[] =
+  PAD("v19     HTTPS   16 foo.example.org. alpn=\"f\\\\oo\\,bar,h2\"");
+static const char d2_f10_1_https_generic_text[] =
+  PAD("v19     HTTPS   \\# 35 (\n"
+      "00 10                                              ; priority\n"
+      "03 66 6f 6f 07 65 78 61 6d 70 6c 65 03 6f 72 67 00 ; target\n"
+      "00 01                                              ; key 1\n"
+      "00 0c                                              ; param length 12\n"
+      "08                                                 ; alpn length 8\n"
+      "66 5c 6f 6f 2c 62 61 72                            ; alpn value\n"
+      "02                                                 ; alpn length 2\n"
+      "68 32                                              ; alpn value\n"
+      ")");
+
+static const char d2_f10_2_svcb_text[] =
+  PAD("v10     SVCB    16 foo.example.org. alpn=f\\\092oo\092,bar,h2");
+static const char d2_f10_2_svcb_generic_text[] =
+  PAD("v10     SVCB    \\# 35 (\n"
+      "00 10                                              ; priority\n"
+      "03 66 6f 6f 07 65 78 61 6d 70 6c 65 03 6f 72 67 00 ; target\n"
+      "00 01                                              ; key 1\n"
+      "00 0c                                              ; param length 12\n"
+      "08                                                 ; alpn length 8\n"
+      "66 5c 6f 6f 2c 62 61 72                            ; alpn value\n"
+      "02                                                 ; alpn length 2\n"
+      "68 32                                              ; alpn value\n"
+      ")");
+
+static const char d2_f10_2_https_text[] =
+  PAD("v20     HTTPS   16 foo.example.org. alpn=f\\\092oo\092,bar,h2");
+static const char d2_f10_2_https_generic_text[] =
+  PAD("v20     HTTPS   \\# 35 (\n"
+      "00 10                                              ; priority\n"
+      "03 66 6f 6f 07 65 78 61 6d 70 6c 65 03 6f 72 67 00 ; target\n"
+      "00 01                                              ; key 1\n"
+      "00 0c                                              ; param length 12\n"
+      "08                                                 ; alpn length 8\n"
+      "66 5c 6f 6f 2c 62 61 72                            ; alpn value\n"
+      "02                                                 ; alpn length 2\n"
+      "68 32                                              ; alpn value\n"
+      ")");
 
 static const rdata_t d2_f10_rdata = RDATA(
   // priority
@@ -237,26 +457,270 @@ static const rdata_t d2_f10_rdata = RDATA(
   0x68, 0x32);
 #endif
 
+// Failure cases copied from NSD
+// svcb.failure-cases-01
+// This example has multiple instances of the same SvcParamKey
+static const char nsd_fc01_text[] =
+  PAD("f01     SVCB   1 foo.example.com. (\n"
+      "                       key123=abc key123=def\n"
+      "                       )");
+
+// svcb.failure-cases-02
+// In the next examples the SvcParamKeys are missing their values.
+static const char nsd_fc02_text[] =
+  PAD("f02     SVCB   1 foo.example.com. mandatory");
+
+// svcb.failure-cases-03
+// In the next examples the SvcParamKeys are missing their values.
+static const char nsd_fc03_text[] =
+  PAD("f03     SVCB   1 foo.example.com. alpn");
+
+// svcb.failure-cases-04
+// In the next examples the SvcParamKeys are missing their values.
+static const char nsd_fc04_text[] =
+  PAD("f04     SVCB   1 foo.example.com. port");
+
+// svcb.failure-cases-05
+// In the next examples the SvcParamKeys are missing their values.
+static const char nsd_fc05_text[] =
+  PAD("f05     SVCB   1 foo.example.com. ipv4hint");
+
+// svcb.failure-cases-06
+// In the next examples the SvcParamKeys are missing their values.
+static const char nsd_fc06_text[] =
+  PAD("f06     SVCB   1 foo.example.com. ipv6hint");
+
+// svcb.failure-cases-07
+// ; The "no-default-alpn" SvcParamKey value MUST be empty
+static const char nsd_fc07_text[] =
+  PAD("f07     SVCB   1 foo.example.com. no-default-alpn=abc");
+
+// svcb.failure-cases-08
+// In this record a mandatory SvcParam is missing
+static const char nsd_fc08_text[] =
+  PAD("f08     SVCB   1 foo.example.com. mandatory=key123");
+
+// svcb.failure-cases-09
+// The "mandatory" SvcParamKey MUST not be included in mandatory list
+static const char nsd_fc09_text[] =
+  PAD("f09     SVCB   1 foo.example.com. mandatory=mandatory");
+
+// svcb.failure-cases-10
+// Here there are multiple instances of the same SvcParamKey in the mandatory list
+static const char nsd_fc10_text[] =
+  PAD("f10     SVCB   1 foo.example.com. (\n"
+      "                      mandatory=key123,key123 key123=abc\n"
+      "                      )");
+
+// svcb.failure-cases-11
+// This example has multiple instances of the same SvcParamKey
+static const char nsd_fc11_text[] =
+  PAD("f11     HTTPS   1 foo.example.com. (\n"
+      "                       key123=abc key123=def\n"
+      "                       )");
+
+// svcb.failure-cases-12
+// In the next examples the SvcParamKeys are missing their values.
+static const char nsd_fc12_text[] =
+  PAD("f12     HTTPS   1 foo.example.com. mandatory");
+
+// svcb.failure-cases-13
+// In the next examples the SvcParamKeys are missing their values.
+static const char nsd_fc13_text[] =
+  PAD("f13     HTTPS   1 foo.example.com. alpn");
+
+// svcb.failure-cases-14
+// In the next examples the SvcParamKeys are missing their values.
+static const char nsd_fc14_text[] =
+  PAD("f14     HTTPS   1 foo.example.com. port");
+
+// svcb.failure-cases-15
+// In the next examples the SvcParamKeys are missing their values.
+static const char nsd_fc15_text[] =
+  PAD("f15     HTTPS   1 foo.example.com. ipv4hint");
+
+// svcb.failure-cases-16
+// In the next examples the SvcParamKeys are missing their values.
+static const char nsd_fc16_text[] =
+  PAD("f16     HTTPS   1 foo.example.com. ipv6hint");
+
+// svcb.failure-cases-17
+// The "no-default-alpn" SvcParamKey value MUST be empty
+static const char nsd_fc17_text[] =
+  PAD("f17     HTTPS   1 foo.example.com. no-default-alpn=abc");
+
+// svcb.failure-cases-18
+// In this record a mandatory SvcParam is missing
+static const char nsd_fc18_text[] =
+  PAD("f18     HTTPS   1 foo.example.com. mandatory=key123");
+
+// svcb.failure-cases-19
+// The "mandatory" SvcParamKey MUST not be included in mandatory list
+static const char nsd_fc19_text[] =
+  PAD("f19     HTTPS   1 foo.example.com. mandatory=mandatory");
+
+// svcb.failure-cases-20
+// Here there are multiple instances of the same SvcParamKey in the mandatory list
+static const char nsd_fc20_text[] =
+  PAD("f20     HTTPS   1 foo.example.com. (\n"
+      "                      mandatory=key123,key123 key123=abc\n"
+      "                      )");
+
+#if 0
+// simdzone cannot detect cross-record errors as no records are kept around.
+// svcb.failure-cases-21
+// Here there are multiple instances of the same SvcParamKey in the mandatory list
+static const char nsd_fc21_text[] =
+  PAD("f21     HTTPS   1 foo.example.com. ech=\"123\"\n"
+      "f21     HTTPS   1 foo.example.com. echconfig=\"123\"");
+#endif
+
+// svcb.failure-cases-22
+// Port mus be a positive number < 65536
+static const char nsd_fc22_text[] =
+  PAD("f22     HTTPS   1 foo.example.com. port=65536");
+
+// svcb.failure-cases-23
+// In the next example the SvcParamKey is missing their value.
+static const char nsd_fc23_text[] =
+  PAD("f23     HTTPS   1 foo.example.com. dohpath");
+
+
+#if 0
+// svcb.success-cases.zone (cut up into separate tests for debuggability)
+// A particular key does not need to have a value
+static const char nsd_s01_text[] =
+  PAD("s01     SVCB   0 . key123");
+static const rdata_t nsd_s01_rdata =
+  RDATA();
+
+// echconfig does not need to have a value
+static const char nsd_s02_text[] =
+  PAD("s02     SVCB   0 . echconfig");
+static const rdata_t nsd_s02_rdata =
+  RDATA();
+
+// When "no-default-alpn" is specified in an RR, "alpn" must also be specified
+// in order for the RR to be "self-consistent"
+static const char nsd_s03_text[] =
+  PAD("s03     HTTPS   0 . alpn="h2,h3" no-default-alpn");
+static const rdata_t nsd_s03_rdata =
+  RDATA();
+
+// SHOULD is not MUST (so allowed)
+// Zone-file implementations SHOULD enforce self-consistency
+static const char nsd_s04_text[] =
+  PAD("s04     HTTPS   0 . no-default-alpn");
+static const rdata_t nsd_s04_rdata =
+  RDATA();
+
+// SHOULD is not MUST (so allowed)
+// (port and no-default-alpn are automatically mandatory keys with HTTPS)
+// Other automatically mandatory keys SHOULD NOT appear in the list either.
+static const char nsd_s05_text[] =
+  PAD("s05     HTTPS   0 . alpn="dot" no-default-alpn port=853 mandatory=port");
+static const rdata_t nsd_s05_rdata =
+  RDATA();
+
+// Any valid base64 is okay for ech
+static const char nsd_s06_text[] =
+  PAD("s06     HTTPS   0 . ech=\"aGVsbG93b3JsZCE=\"");
+static const rdata_t nsd_s06_rdata =
+  RDATA();
+
+// echconfig is an alias for ech
+static const char nsd_s07_text[] =
+  PAD("s07     HTTPS   0 . echconfig=\"aGVsbG93b3JsZCE=\"");
+static const rdata_t nsd_s07_rdata =
+  RDATA();
+
+// dohpath can be (non-)quoted
+static const char nsd_s08_text[] =
+  PAD("s08     HTTPS   0 . alpn=h2 dohpath=\"/dns-query{?dns}\"");
+static const rdata_t nsd_s08_rdata =
+  RDATA();
+
+static const char nsd_s09_text[] =
+  PAD("s09     HTTPS   0 . alpn=h2 dohpath=/dns-query{é?dns}");
+static const rdata_t nsd_s09_rdata =
+  RDATA();
+#endif
+
+
+
 typedef struct test test_t;
 struct test {
-  const uint16_t type;
+  uint16_t type;
+  int32_t code;
   const char *text;
   const rdata_t *rdata;
 };
 
 static const test_t tests[] = {
-  { ZONE_HTTPS, d1_text, &d1_rdata },
-  { ZONE_SVCB, d2_f3_text, &d2_f3_rdata },
-  { ZONE_SVCB, d2_f4_text, &d2_f4_rdata },
-  { ZONE_SVCB, d2_f5_text, &d2_f5_rdata },
-  { ZONE_SVCB, d2_f6_text, &d2_f6_rdata },
-  { ZONE_SVCB, d2_f7_text, &d2_f7_rdata },
-  { ZONE_SVCB, d2_f8_text, &d2_f8_rdata },
-  { ZONE_SVCB, d2_f9_text, &d2_f9_rdata },
+  { ZONE_SVCB, 0, d1_svcb_text, &d1_rdata },
+  { ZONE_SVCB, 0, d1_svcb_generic_text, &d1_rdata },
+  { ZONE_HTTPS, 0, d1_https_text, &d1_rdata },
+  { ZONE_HTTPS, 0, d1_https_generic_text, &d1_rdata},
+  { ZONE_SVCB, 0, d2_f3_svcb_text, &d2_f3_rdata },
+  { ZONE_SVCB, 0, d2_f3_svcb_generic_text, &d2_f3_rdata },
+  { ZONE_HTTPS, 0, d2_f3_https_text, &d2_f3_rdata },
+  { ZONE_HTTPS, 0, d2_f3_https_generic_text, &d2_f3_rdata },
+  { ZONE_SVCB, 0, d2_f4_svcb_text, &d2_f4_rdata },
+  { ZONE_SVCB, 0, d2_f4_svcb_generic_text, &d2_f4_rdata },
+  { ZONE_HTTPS, 0, d2_f4_https_text, &d2_f4_rdata },
+  { ZONE_HTTPS, 0, d2_f4_https_generic_text, &d2_f4_rdata },
+  { ZONE_SVCB, 0, d2_f5_svcb_text, &d2_f5_rdata },
+  { ZONE_SVCB, 0, d2_f5_svcb_generic_text, &d2_f5_rdata },
+  { ZONE_HTTPS, 0, d2_f5_https_text, &d2_f5_rdata },
+  { ZONE_HTTPS, 0, d2_f5_https_generic_text, &d2_f5_rdata },
+  { ZONE_SVCB, 0, d2_f6_svcb_text, &d2_f6_rdata },
+  { ZONE_SVCB, 0, d2_f6_svcb_generic_text, &d2_f6_rdata },
+  { ZONE_HTTPS, 0, d2_f6_https_text, &d2_f6_rdata },
+  { ZONE_HTTPS, 0, d2_f6_https_generic_text, &d2_f6_rdata },
+  { ZONE_SVCB, 0, d2_f7_svcb_text, &d2_f7_rdata },
+  { ZONE_SVCB, 0, d2_f7_svcb_generic_text, &d2_f7_rdata },
+  { ZONE_HTTPS, 0, d2_f7_https_text, &d2_f7_rdata },
+  { ZONE_HTTPS, 0, d2_f7_https_generic_text, &d2_f7_rdata },
+  { ZONE_SVCB, 0, d2_f8_svcb_text, &d2_f8_rdata },
+  { ZONE_SVCB, 0, d2_f8_svcb_generic_text, &d2_f8_rdata },
+  { ZONE_HTTPS, 0, d2_f8_https_text, &d2_f8_rdata },
+  { ZONE_HTTPS, 0, d2_f8_https_generic_text, &d2_f8_rdata },
+  { ZONE_SVCB, 0, d2_f9_svcb_text, &d2_f9_rdata },
+  { ZONE_SVCB, 0, d2_f9_svcb_generic_text, &d2_f9_rdata },
+  { ZONE_HTTPS, 0, d2_f9_https_text, &d2_f9_rdata },
+  { ZONE_HTTPS, 0, d2_f9_https_generic_text, &d2_f9_rdata },
 #if 0
-  { ZONE_SVCB, d2_f10_1_text, &d2_f10_rdata },
-  { ZONE_SVCB, d2_f10_2_text, &d2_f10_rdata }
+  { ZONE_SVCB, 0, d2_f10_1_svcb_text, &d2_f10_rdata },
+  { ZONE_SVCB, 0, d2_f10_1_svcb_generic_text, &d2_f10_rdata },
+  { ZONE_HTTPS, 0, d2_f10_1_https_text, &d2_f10_rdata },
+  { ZONE_HTTPS, 0, d2_f10_1_https_generic_text, &d2_f10_rdata },
+  { ZONE_SVCB, 0, d2_f10_2_svcb_text, &d2_f10_rdata },
+  { ZONE_SVCB, 0, d2_f10_2_svcb_generic_text, &d2_f10_rdata },
+  { ZONE_HTTPS, 0, d2_f10_2_https_text, &d2_f10_rdata },
+  { ZONE_HTTPS, 0, d2_f10_2_https_generic_text, &d2_f10_rdata },
 #endif
+  { ZONE_SVCB, ZONE_SEMANTIC_ERROR, nsd_fc01_text, NULL },
+  { ZONE_SVCB, ZONE_SEMANTIC_ERROR, nsd_fc02_text, NULL },
+  { ZONE_SVCB, ZONE_SEMANTIC_ERROR, nsd_fc03_text, NULL },
+  { ZONE_SVCB, ZONE_SEMANTIC_ERROR, nsd_fc04_text, NULL },
+  { ZONE_SVCB, ZONE_SEMANTIC_ERROR, nsd_fc05_text, NULL },
+  { ZONE_SVCB, ZONE_SEMANTIC_ERROR, nsd_fc06_text, NULL },
+  { ZONE_SVCB, ZONE_SEMANTIC_ERROR, nsd_fc07_text, NULL },
+  { ZONE_SVCB, ZONE_SEMANTIC_ERROR, nsd_fc08_text, NULL },
+  { ZONE_SVCB, ZONE_SEMANTIC_ERROR, nsd_fc09_text, NULL },
+  { ZONE_SVCB, ZONE_SEMANTIC_ERROR, nsd_fc10_text, NULL },
+  { ZONE_HTTPS, ZONE_SEMANTIC_ERROR, nsd_fc11_text, NULL },
+  { ZONE_HTTPS, ZONE_SEMANTIC_ERROR, nsd_fc12_text, NULL },
+  { ZONE_HTTPS, ZONE_SEMANTIC_ERROR, nsd_fc13_text, NULL },
+  { ZONE_HTTPS, ZONE_SEMANTIC_ERROR, nsd_fc14_text, NULL },
+  { ZONE_HTTPS, ZONE_SEMANTIC_ERROR, nsd_fc15_text, NULL },
+  { ZONE_HTTPS, ZONE_SEMANTIC_ERROR, nsd_fc16_text, NULL },
+  { ZONE_HTTPS, ZONE_SEMANTIC_ERROR, nsd_fc17_text, NULL },
+  { ZONE_HTTPS, ZONE_SEMANTIC_ERROR, nsd_fc18_text, NULL },
+  { ZONE_HTTPS, ZONE_SEMANTIC_ERROR, nsd_fc19_text, NULL },
+  { ZONE_HTTPS, ZONE_SEMANTIC_ERROR, nsd_fc20_text, NULL },
+  { ZONE_HTTPS, ZONE_SYNTAX_ERROR, nsd_fc22_text, NULL },
+  { ZONE_HTTPS, ZONE_SEMANTIC_ERROR, nsd_fc23_text, NULL }
 };
 
 static int32_t add_rr(
@@ -274,11 +738,14 @@ static int32_t add_rr(
   (void)owner;
   (void)class;
   (void)ttl;
-  (void)rdlength;
-  (void)rdata;
-  assert_int_equal(type, test->type);
-  assert_int_equal(rdlength, test->rdata->length);
-  assert_memory_equal(rdata, test->rdata->octets, rdlength);
+  if (type != test->type)
+    return ZONE_SYNTAX_ERROR;
+  if (test->code != ZONE_SUCCESS)
+    return ZONE_SUCCESS;
+  if (rdlength != test->rdata->length)
+    return ZONE_SYNTAX_ERROR;
+  if (memcmp(rdata, test->rdata->octets, rdlength) != 0)
+    return ZONE_SYNTAX_ERROR;
   return ZONE_SUCCESS;
 }
 
@@ -291,13 +758,13 @@ void rfc9460_test_vectors(void **state)
   (void)state;
 
   for (size_t i = 0, n = sizeof(tests)/sizeof(tests[0]); i < n; i++) {
-    test_t test = tests[i];
+    const test_t *test = &tests[i];
     zone_parser_t parser = { 0 };
     zone_name_buffer_t name;
     zone_rdata_buffer_t rdata;
     zone_buffers_t buffers = { 1, &name, &rdata };
     zone_options_t options = { 0 };
-    int32_t result;
+    int32_t code;
 
     options.accept.callback = add_rr;
     options.origin.octets = origin;
@@ -305,9 +772,9 @@ void rfc9460_test_vectors(void **state)
     options.default_ttl = 3600;
     options.default_class = ZONE_IN;
 
-    fprintf(stderr, "INPUT: '%s'\n", tests[i].text);
+    fprintf(stderr, "INPUT: '%s'\n", test->text);
 
-    result = zone_parse_string(&parser, &options, &buffers, tests[i].text, strlen(tests[i].text), &test);
-    assert_int_equal(result, ZONE_SUCCESS);
+    code = zone_parse_string(&parser, &options, &buffers, test->text, strlen(test->text), (void *)test);
+    assert_int_equal(code, test->code);
   }
 }

--- a/tests/types.c
+++ b/tests/types.c
@@ -748,11 +748,11 @@ static const rdata_t zonemd_rdata =
         0xf2, 0x2c, 0x6b, 0xd6, 0x47, 0xde);
 
 static const char svcb_text[] =
-  PAD("foo. 1 IN SVCB 0 foo. mandatory=mandatory,key16");
+  PAD("foo. 1 IN SVCB 0 foo. key16= mandatory=key16");
 static const rdata_t svcb_rdata =
   RDATA(0x00, 0x00,
         3, 'f', 'o', 'o', 0,
-        0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x10);
+        0x00, 0x00, 0x00, 0x02, 0x00, 0x10, 0x00, 0x10, 0x00, 0x00);
 
 static const char spf_text[] =
   PAD(" SPF \"v=spf1 +all\"");


### PR DESCRIPTION
Ported/copied all tests from `svcb.tdir`. There's still some tests that fail with regards to double escaping in SVCB RRs. Also, I still need to add tests for testing the non-strict (if server is a secondary) and tests that verify SVCB and HTTPS RRs when RDATA is specified in generic notation.