### PR TITLE
Add unit tests to ensure syntax errors are caught

### DIFF
--- a/include/zone.h
+++ b/include/zone.h
@@ -240,7 +240,7 @@ struct zone_file {
   FILE *handle;
   bool grouped;
   bool start_of_line;
-  enum { ZONE_HAVE_DATA, ZONE_READ_ALL_DATA, ZONE_NO_MORE_DATA } end_of_file;
+  uint8_t end_of_file;
   struct {
     size_t index, length, size;
     char *data;

--- a/src/fallback/scanner.h
+++ b/src/fallback/scanner.h
@@ -153,10 +153,10 @@ static really_inline int32_t reindex(parser_t *parser)
   if (parser->file->end_of_file) {
     assert(left < ZONE_BLOCK_SIZE);
     if (!left) {
-      parser->file->end_of_file = ZONE_NO_MORE_DATA;
+      parser->file->end_of_file = NO_MORE_DATA;
     } else if (((uintptr_t)tape_limit - (uintptr_t)tape) >= left) {
       scan(parser, data, data + left);
-      parser->file->end_of_file = ZONE_NO_MORE_DATA;
+      parser->file->end_of_file = NO_MORE_DATA;
       parser->file->buffer.index += left;
       parser->file->state.follows_contiguous = 0;
     }

--- a/src/generic/format.h
+++ b/src/generic/format.h
@@ -376,7 +376,7 @@ static inline int32_t parse(parser_t *parser)
 
       code = parse_rr(parser, &token);
     } else if (is_end_of_file(&token)) {
-      if (parser->file->end_of_file == ZONE_NO_MORE_DATA)
+      if (parser->file->end_of_file == NO_MORE_DATA)
         break;
     } else if (is_line_feed(&token)) {
       assert(token.code == LINE_FEED);

--- a/src/generic/parser.h
+++ b/src/generic/parser.h
@@ -443,12 +443,6 @@ static never_inline void maybe_take(parser_t *parser, token_t *token)
           SYNTAX_ERROR(parser, token, "Missing closing brace");
         token->data = end_of_file;
         token->length = 1;
-        if (!parser->file->includer)
-          return;
-        file_t *file = parser->file;
-        parser->file = parser->file->includer;
-        parser->owner = &parser->file->owner;
-        zone_close_file(parser, file);
         return;
       } else if (unlikely((code = advance(parser)) < 0)) {
         ERROR(parser, token, code);
@@ -912,12 +906,6 @@ static never_inline int32_t maybe_take_delimiter(
           SYNTAX_ERROR(parser, token, "Missing closing brace");
         token->data = end_of_file;
         token->length = 1;
-        if (!parser->file->includer)
-          return 0;
-        file_t *file = parser->file;
-        parser->file = parser->file->includer;
-        parser->owner = &parser->file->owner;
-        zone_close_file(parser, file);
         return 0;
       }
 

--- a/src/generic/scanner.h
+++ b/src/generic/scanner.h
@@ -312,7 +312,7 @@ static really_inline int32_t reindex(parser_t *parser)
   if (parser->file->end_of_file) {
     assert(left < ZONE_BLOCK_SIZE);
     if (!left) {
-      parser->file->end_of_file = ZONE_NO_MORE_DATA;
+      parser->file->end_of_file = NO_MORE_DATA;
     } else if (((uintptr_t)tape_limit - (uintptr_t)tape) >= left) {
       // input is required to be padded, but may contain garbage
       uint8_t buffer[ZONE_BLOCK_SIZE] = { 0 };
@@ -322,7 +322,7 @@ static really_inline int32_t reindex(parser_t *parser)
       scan(parser, &block);
       block.contiguous &= ~clear;
       write_indexes(parser, &block, clear);
-      parser->file->end_of_file = ZONE_NO_MORE_DATA;
+      parser->file->end_of_file = NO_MORE_DATA;
       parser->file->buffer.index += left;
     }
   }

--- a/src/zone.c
+++ b/src/zone.c
@@ -222,9 +222,8 @@ static int32_t open_file(
   file->buffer.length = 0;
   file->buffer.index = 0;
   file->start_of_line = true;
-  file->end_of_file = ZONE_HAVE_DATA;
-  file->fields.tape[0] = file->buffer.data;
-  file->fields.tape[1] = NULL;
+  file->end_of_file = 0;
+  file->fields.tape[0] = file->fields.tape[1] = file->buffer.data;
   file->fields.head = file->fields.tape;
   file->fields.tail = file->fields.tape;
   file->lines.tape[0] = 0;
@@ -376,6 +375,8 @@ int32_t zone_parse_string(
   zone_file_t *file;
   int32_t result;
 
+  if (!length || string[length] != '\0')
+    return ZONE_BAD_PARAMETER;
   if ((result = check_options(options)) < 0)
     return result;
 
@@ -393,9 +394,8 @@ int32_t zone_parse_string(
   file->buffer.size = length;
   file->buffer.data = (char *)string;
   file->start_of_line = true;
-  file->end_of_file = ZONE_READ_ALL_DATA;
-  file->fields.tape[0] = "\0";
-  file->fields.tape[1] = NULL;
+  file->end_of_file = 1;
+  file->fields.tape[0] = file->fields.tape[1] = &string[length];
   file->fields.head = file->fields.tape;
   file->fields.tail = file->fields.tape;
   file->lines.tape[0] = 0;

--- a/src/zone.c
+++ b/src/zone.c
@@ -255,8 +255,8 @@ nonnull_all
 void zone_close_file(
   parser_t *parser, zone_file_t *file)
 {
-  assert((file->name == not_a_file) == !file->handle);
-  assert((file->path == not_a_file) == !file->handle);
+  assert(file->name != not_a_file || !file->handle);
+  assert(file->path != not_a_file || !file->handle);
 
   if (!file->handle)
     return;

--- a/tests/syntax.c
+++ b/tests/syntax.c
@@ -615,3 +615,53 @@ void no_famous_last_words(void **state)
   assert_int_equal(code, ZONE_SUCCESS);
   assert_true(count == 0);
 }
+
+/*!cmocka */
+void the_include_that_wasnt(void **state)
+{
+  (void)state;
+
+  int32_t code;
+  size_t count = 0;
+
+  char *path = generate_include(" ");
+  assert_non_null(path);
+  char dummy[16];
+  int length = snprintf(dummy, sizeof(dummy), "$INCLUDE \"%s\"\n", path);
+  assert_true(length > 0 && length < INT_MAX - ZONE_PADDING_SIZE);
+  char *include = malloc((size_t)length + 1 + ZONE_PADDING_SIZE);
+  assert_non_null(include);
+  (void)snprintf(include, (size_t)length + 1, "$INCLUDE \"%s\"\n", path);
+  remove_include(path);
+  free(path);
+  code = parse(include, &count);
+  free(include);
+  assert_int_equal(code, ZONE_READ_ERROR);
+}
+
+/*!cmocka */
+void been_there_done_that(void **state)
+{
+  (void)state;
+
+  int32_t code;
+  size_t count = 0;
+
+  char *path = generate_include(" ");
+  assert_non_null(path);
+  FILE* handle = fopen(path, "wb");
+  assert_non_null(handle);
+  char dummy[16];
+  int length = snprintf(dummy, sizeof(dummy), "$INCLUDE \"%s\"\n", path);
+  assert_true(length > 0 && length < INT_MAX - ZONE_PADDING_SIZE);
+  char *include = malloc((size_t)length + 1 + ZONE_PADDING_SIZE);
+  assert_non_null(include);
+  (void)snprintf(include, (size_t)length + 1, "$INCLUDE \"%s\"\n", path);
+  int result = fputs(include, handle);
+  assert_true(result >= 0);
+  (void)fclose(handle);
+  free(path);
+  code = parse(include, &count);
+  free(include);
+  assert_int_equal(code, ZONE_SYNTAX_ERROR);
+}


### PR DESCRIPTION
Ensure syntax errors like unterminated strings, etc are caught by the parser. Upon completion, this fixes #10.