### PR TITLE
Add MinGW build to GitHub Actions

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -27,6 +27,10 @@ jobs:
             generator: "Visual Studio 17 2022"
             build_type: Debug
             build_tool_options: "-nologo -verbosity:minimal -maxcpucount:4 -p:CL_MPCount=4"
+          - os: windows-2022
+            cc: 'C:/mingw64/bin/gcc.exe'
+            generator: 'MinGW Makefiles'
+            build_type: Debug
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -43,9 +47,19 @@ jobs:
         run: |
           $python_base = python -m site --user-base
           Write-Output "$python_base\\bin" >> $GITHUB_PATH
+      - uses: msys2/setup-msys2@v2
+        if: runner.os == 'Windows' && matrix.generator == 'MinGW Makefiles'
+        with:
+          update: false
+          release: false
+          install: make gcc
       - name: 'Install Conan C/C++ package manager'
         id: install_conan
         shell: bash
+        env:
+          CC: ${{matrix.cc}}
+          # Set CONAN_BASH_PATH to avoid having to build msys2 for Conan packages.
+          CONAN_BASH_PATH: "C:\\msys64\\usr\\bin\\bash.exe"
         run: |
           pip install conan --user --upgrade
           conan profile detect
@@ -68,6 +82,7 @@ jobs:
           BUILD_TYPE: ${{matrix.build_type}}
           BUILD_TOOL_OPTIONS: ${{matrix.build_tool_options}}
           WARNINGS_AS_ERRORS: ${{matrix.warnings_as_errors}}
+          CONAN_BASH_PATH: "C:\\msys64\\usr\\bin\\bash.exe"
         run: |
           set -e -x
           mkdir build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,6 +130,16 @@ if(SANITIZER)
   endforeach()
 endif()
 
+if(MINGW)
+  # Require at least Windows 7
+  add_definitions(-D_WIN32_WINNT=_WIN32_WINNT_WIN7)
+  add_definitions(-DNTDDI_VERSION=NTDDI_WIN7)
+  add_definitions(-D__USE_MINGW_ANSI_STDIO=1) # prefer C99 conformance
+  # Do not prefix libraries with "lib"
+  set(CMAKE_SHARED_LIBRARY_PREFIX "")
+  set(CMAKE_STATIC_LIBRARY_PREFIX "")
+endif()
+
 add_library(zone STATIC)
 if(WIN32)
   target_link_libraries(zone INTERFACE shlwapi)

--- a/src/bench.c
+++ b/src/bench.c
@@ -23,7 +23,7 @@
 #include "attributes.h"
 #include "diagnostic.h"
 
-#if _WIN32
+#if _MSC_VER
 #define strcasecmp(s1, s2) _stricmp(s1, s2)
 #define strncasecmp(s1, s2, n) _strnicmp(s1, s2, n)
 #endif

--- a/src/generic/endian.h
+++ b/src/generic/endian.h
@@ -9,7 +9,7 @@
 #ifndef ENDIAN_H
 #define ENDIAN_H
 
-#if _MSC_VER
+#if _WIN32
 #include <stdlib.h>
 
 #define LITTLE_ENDIAN 1234

--- a/src/generic/parser.h
+++ b/src/generic/parser.h
@@ -14,7 +14,7 @@
 #include <stdint.h>
 #include <string.h>
 
-#if _WIN32
+#if _MSC_VER
 # define strncasecmp(s1, s2, n) _strnicmp((s1), (s2), (n))
 #else
 # include <strings.h>

--- a/src/zone.c
+++ b/src/zone.c
@@ -28,8 +28,10 @@ typedef zone_parser_t parser_t; // convenience
 #include "isadetection.h"
 
 #if _WIN32
-#define strcasecmp(s1, s2) _stricmp(s1, s2)
-#define strncasecmp(s1, s2, n) _strnicmp(s1, s2, n)
+# if _MSC_VER
+#   define strcasecmp(s1, s2) _stricmp(s1, s2)
+#   define strncasecmp(s1, s2, n) _strnicmp(s1, s2, n)
+# endif
 
 static char *strndup(const char *s, size_t n)
 {
@@ -154,7 +156,7 @@ static int32_t open_file(
   const char *rel = file->name;
 
 #if _WIN32
-  char buf[1];
+  char buf[4];
   // relative include paths are relative to including file
   if (file != &parser->first && PathIsRelative(path)) {
     assert(parser->file->path != not_a_file);


### PR DESCRIPTION
Review comments by @wcawijngaards suggested replacing an occurrence of the `_MSC_VER` macro by `_WIN32` to allow for building using MinGW. This PR resolves a number of other issues too and adds a build to the build-test workflow to ensure MinGW builds keep working.