### PR TITLE
Overhaul file and buffer operation

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -57,6 +57,9 @@ jobs:
           update: false
           release: false
           install: make gcc
+      - name: 'Workaround for actions/runner-images#9491'
+        if: runner.os == 'Linux'
+        run: sudo sysctl vm.mmap_rnd_bits=28
       - name: 'Install Conan C/C++ package manager'
         id: install_conan
         shell: bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,9 +141,6 @@ if(MINGW)
 endif()
 
 add_library(zone STATIC)
-if(WIN32)
-  target_link_libraries(zone INTERFACE shlwapi)
-endif()
 
 generate_export_header(
   zone BASE_NAME ZONE EXPORT_FILE_NAME include/zone/export.h)

--- a/include/zone.h
+++ b/include/zone.h
@@ -319,14 +319,13 @@ typedef struct {
   uint32_t default_ttl;
   uint16_t default_class;
   struct {
-    /** Message categories to write out. */
-    /** All categories are printed if no categories are selected and no
-        custom callback was specified. */
-    uint32_t categories;
-    /** Callback used to write out log messages. */
+    /** Priorities NOT to write out. */
+    uint32_t mask;
+    /** Callback invoked to write out log messages. */
     zone_log_t callback;
   } log;
   struct {
+    /** Callback invoked for each RR. */
     zone_accept_t callback;
   } accept;
 } zone_options_t;
@@ -429,13 +428,13 @@ zone_nonnull((1,2,3,4));
  * error message format consistent.
  *
  * @param[in]  parser    Zone parser
- * @param[in]  category  Log category
+ * @param[in]  priority  Log priority
  * @param[in]  format    Format string compatible with printf
  * @param[in]  ...       Variadic arguments corresponding to #format
  */
 ZONE_EXPORT void zone_log(
   zone_parser_t *parser,
-  uint32_t category,
+  uint32_t priority,
   const char *format,
   ...)
 zone_nonnull((1,3))
@@ -445,13 +444,13 @@ zone_format_printf(3,4);
  * @brief Write error message to active log handler.
  *
  * @param[in]  parser     Zone parser
- * @param[in]  category   Log category
+ * @param[in]  priority   Log priority
  * @param[in]  format     Format string compatible with printf
  * @param[in]  arguments  Argument list
  */
 ZONE_EXPORT void zone_vlog(
   zone_parser_t *parser,
-  uint32_t category,
+  uint32_t priority,
   const char *format,
   va_list arguments)
 zone_nonnull((1,3));
@@ -461,7 +460,7 @@ zone_nonnull((1,2))
 zone_format_printf(2,3)
 zone_error(zone_parser_t *parser, const char *format, ...)
 {
-  if (!(parser->options.log.categories & ZONE_ERROR))
+  if (!(ZONE_ERROR & ~parser->options.log.mask))
     return;
   va_list arguments;
   va_start(arguments, format);
@@ -474,7 +473,7 @@ zone_nonnull((1,2))
 zone_format_printf(2,3)
 zone_warning(zone_parser_t *parser, const char *format, ...)
 {
-  if (!(parser->options.log.categories & ZONE_WARNING))
+  if (!(ZONE_WARNING & ~parser->options.log.mask))
     return;
   va_list arguments;
   va_start(arguments, format);
@@ -487,7 +486,7 @@ zone_nonnull((1,2))
 zone_format_printf(2,3)
 zone_info(zone_parser_t *parser, const char *format, ...)
 {
-  if (!(parser->options.log.categories & ZONE_INFO))
+  if (!(ZONE_INFO & ~parser->options.log.mask))
     return;
   va_list arguments;
   va_start(arguments, format);

--- a/include/zone.h
+++ b/include/zone.h
@@ -235,8 +235,8 @@ struct zone_file {
   // in error reports
   size_t span; /**< number of lines spanned by record */
   size_t line; /**< starting line of record */
-  char *name;
-  char *path;
+  char *name; /**< filename in control directive */
+  char *path; /**< absolute path */
   FILE *handle;
   bool grouped;
   bool start_of_line;
@@ -357,10 +357,11 @@ struct zone_parser {
   struct {
     size_t size;
     struct {
-      size_t serial;
+      size_t active;
       zone_name_buffer_t *blocks;
     } owner;
     struct {
+      size_t active;
       zone_rdata_buffer_t *blocks;
     } rdata;
   } buffers;

--- a/include/zone.h
+++ b/include/zone.h
@@ -312,6 +312,8 @@ typedef struct {
   /** Disable $INCLUDE directive. */
   /** Useful in setups where untrusted input may be offered. */
   bool no_includes;
+  /** Maximum $INCLUDE depth. 0 for default. */
+  uint32_t include_limit;
   /** Enable 1h2m3s notations for TTLS. */
   bool pretty_ttls;
   /** Origin in wire format. */

--- a/src/generic/format.h
+++ b/src/generic/format.h
@@ -374,7 +374,7 @@ static inline int32_t parse(parser_t *parser)
           else if (token.length == 8 && memcmp(token.data, "$INCLUDE", 8) == 0)
             code = parse_dollar_include(parser, &token);
           else
-            SYNTAX_ERROR(parser, "Invalid control entry");
+            SYNTAX_ERROR(parser, "Unknown control entry");
           continue;
         }
 
@@ -382,6 +382,8 @@ static inline int32_t parse(parser_t *parser)
           return code;
         if ((code = take_contiguous(parser, &rr, &fields[0], &token)) < 0)
           return code;
+      } else if (unlikely(!parser->owner->length)) {
+        SYNTAX_ERROR(parser, "No last stated owner");
       }
 
       code = parse_rr(parser, &token);

--- a/src/zone.c
+++ b/src/zone.c
@@ -392,6 +392,10 @@ static int32_t initialize_parser(
   parser->owner = &parser->buffers.owner.blocks[0];
   parser->owner->length = 0;
   parser->rdata = &parser->buffers.rdata.blocks[0];
+
+  if (!parser->options.no_includes && !parser->options.include_limit)
+    parser->options.include_limit = 10; // arbitrary, default in NSD
+
   return 0;
 }
 

--- a/src/zone.c
+++ b/src/zone.c
@@ -459,11 +459,11 @@ int32_t zone_parse_string(
 zone_nonnull((1,3))
 static void print_message(
   zone_parser_t *parser,
-  uint32_t category,
+  uint32_t priority,
   const char *message,
   void *user_data)
 {
-  FILE *output = category == ZONE_INFO ? stdout : stderr;
+  FILE *output = priority == ZONE_INFO ? stdout : stderr;
   const char *format = "%s:%zu: %s\n";
   (void)user_data;
   fprintf(output, format, parser->file->name, parser->file->line, message);
@@ -471,7 +471,7 @@ static void print_message(
 
 void zone_vlog(
   zone_parser_t *parser,
-  uint32_t category,
+  uint32_t priority,
   const char *format,
   va_list arguments)
 {
@@ -486,22 +486,22 @@ void zone_vlog(
   if (parser->options.log.callback)
     callback = parser->options.log.callback;
 
-  callback(parser, category, message, parser->user_data);
+  callback(parser, priority, message, parser->user_data);
 }
 
 void zone_log(
   zone_parser_t *parser,
-  uint32_t category,
+  uint32_t priority,
   const char *format,
   ...)
 {
   va_list arguments;
 
-  if (!(parser->options.log.categories & category))
+  if (!(priority & ~parser->options.log.mask))
     return;
 
   va_start(arguments, format);
-  zone_vlog(parser, category, format, arguments);
+  zone_vlog(parser, priority, format, arguments);
   va_end(arguments);
 }
 

--- a/src/zone.c
+++ b/src/zone.c
@@ -14,62 +14,22 @@
 #include <sys/stat.h>
 #include <stdlib.h>
 #include <limits.h>
-#if _WIN32
-# include <windows.h>
-# include <shlwapi.h>
-#endif
+#include <stddef.h>
 
 #include "zone.h"
 
 typedef zone_parser_t parser_t; // convenience
+typedef zone_file_t file_t;
 
 #include "attributes.h"
 #include "diagnostic.h"
-#include "isadetection.h"
 
-#if _WIN32
-# if _MSC_VER
-#   define strcasecmp(s1, s2) _stricmp(s1, s2)
-#   define strncasecmp(s1, s2, n) _strnicmp(s1, s2, n)
-# endif
-
-static char *strndup(const char *s, size_t n)
-{
-  char *p;
-  if ((p = malloc(n + 1))) {
-    memcpy(p, s, n);
-    p[n] = '\0';
-  }
-  return p;
-}
+#if _MSC_VER
+# define strcasecmp(s1, s2) _stricmp(s1, s2)
+# define strncasecmp(s1, s2, n) _strnicmp(s1, s2, n)
 #endif
 
 static const char not_a_file[] = "<string>";
-
-static int32_t check_options(const zone_options_t *options)
-{
-  if (!options->accept.callback)
-    return ZONE_BAD_PARAMETER;
-  if (!options->default_ttl || options->default_ttl > INT32_MAX)
-    return ZONE_BAD_PARAMETER;
-  if (!options->origin.octets || !options->origin.length)
-    return ZONE_BAD_PARAMETER;
-
-  const uint8_t *root = &options->origin.octets[options->origin.length - 1];
-  if (root[0] != 0)
-    return ZONE_BAD_PARAMETER;
-  const uint8_t *label = &options->origin.octets[0];
-  while (label < root) {
-    if (root - label < label[0])
-      return ZONE_BAD_PARAMETER;
-    label += label[0] + 1;
-  }
-
-  if (label != root)
-    return ZONE_BAD_PARAMETER;
-
-  return 0;
-}
 
 #include "config.h"
 #include "isadetection.h"
@@ -142,126 +102,114 @@ static int32_t parse(parser_t *parser, void *user_data)
 diagnostic_push()
 msvc_diagnostic_ignored(4996)
 
-nonnull_all
-static int32_t open_file(
-  parser_t *parser, zone_file_t *file, const char *path, size_t length)
-{
-  char *abs = NULL;
-
-  (void)parser;
-
-  if (!(file->name = strndup(path, length)))
-    return ZONE_OUT_OF_MEMORY;
-
-  const char *rel = file->name;
-
 #if _WIN32
-  char buf[4];
-  // relative include paths are relative to including file
-  if (file != &parser->first && PathIsRelative(path)) {
-    assert(parser->file->path != not_a_file);
-    assert(parser->file->handle != NULL);
-    const char *dir = parser->file->path;
-    int dirlen = 0;
-    for (int i = 0; i < INT32_MAX && dir[i]; i++) {
-      if (dir[i] == '/' || dir[i] == '\\')
-        dirlen = i + 1;
-    }
-    int len;
-    len = snprintf(buf, sizeof(buf), "%.*s\\%s", dirlen, dir, file->name);
-    assert(len != -1);
-    if (!(abs = malloc(len + 1)))
-      return ZONE_READ_ERROR;
-    (void)snprintf(abs, len + 1, "%.*s\\%s", dirlen, dir, file->name);
-    rel = abs;
-  }
-  DWORD size = GetFullPathName(rel, sizeof(buf), buf, NULL);
-  if (!size)
-    goto read_error;
-  if (!(file->path = malloc(size)))
-    goto out_of_memory;
-  (void)GetFullPathName(rel, size, file->path, NULL);
-#else
-  char buf[PATH_MAX];
-  if (file != &parser->first && path[0] != '/') {
-    assert(parser->file->path != not_a_file);
-    assert(parser->file->handle != NULL);
-    const char *dir = parser->file->path;
-    int dirlen = 0;
-    for (int i = 0; i < INT32_MAX && dir[i]; i++) {
-      if (dir[i] == '/')
-        dirlen = i + 1;
-    }
-    int len;
-    len = snprintf(buf, sizeof(buf), "%.*s/%s", dirlen, dir, file->name);
-    if (!(abs = malloc((size_t)len + 1)))
-      return ZONE_OUT_OF_MEMORY;
-    (void)snprintf(abs, (size_t)len + 1, "%.*s/%s", dirlen, dir, file->name);
-    rel = abs;
-  }
-  if (!realpath(rel, buf))
-    goto read_error;
-  if (!(file->path = strdup(buf)))
-    goto out_of_memory;
-#endif
-  if (abs)
-    free(abs);
-  abs = NULL;
-
-  if (!(file->handle = fopen(file->path, "rb")))
-    switch (errno) {
-      case ENOMEM:
-        return ZONE_OUT_OF_MEMORY;
-      default:
-        return ZONE_READ_ERROR;
-    }
-
-  if (!(file->buffer.data = malloc(ZONE_WINDOW_SIZE + 1)))
-    return ZONE_OUT_OF_MEMORY;
-
-  file->buffer.data[0] = '\0';
-  file->buffer.size = ZONE_WINDOW_SIZE;
-  file->buffer.length = 0;
-  file->buffer.index = 0;
-  file->start_of_line = true;
-  file->end_of_file = 0;
-  file->fields.tape[0] = file->fields.tape[1] = file->buffer.data;
-  file->fields.head = file->fields.tape;
-  file->fields.tail = file->fields.tape;
-  file->lines.tape[0] = 0;
-  file->lines.head = file->lines.tape;
-  file->lines.tail = file->lines.tape;
-  return 0;
-read_error:
-  if (abs) free(abs);
-  return ZONE_READ_ERROR;
-out_of_memory:
-  if (abs) free(abs);
-  return ZONE_OUT_OF_MEMORY;
-}
-
-diagnostic_pop()
-
-static void set_defaults(parser_t *parser)
+nonnull_all
+static bool is_separator(int c)
 {
-  if (!parser->options.log.callback && !parser->options.log.categories)
-    parser->options.log.categories = (uint32_t)-1;
-  parser->owner = &parser->file->owner;
-  parser->rdata = &parser->buffers.rdata.blocks[0];
+  return c == '\\' || c == '/';
 }
-
-diagnostic_push()
-clang_diagnostic_ignored(missing-prototypes)
 
 nonnull_all
-void zone_close_file(
-  parser_t *parser, zone_file_t *file)
+static bool is_rooted(const char *s)
 {
-  assert(file);
+  if ((s[0] >= 'A' && s[0] <= 'Z') || (s[0] >= 'a' && s[0] <= 'z'))
+    return s[1] == ':';
+  return false;
+}
+
+nonnull_all
+static bool is_relative(const char *s)
+{
+  // rooted paths can be relative, e.g. C:foo
+  if (is_rooted(s))
+    return !is_separator((unsigned char)s[2]);
+  if (is_separator((unsigned char)s[0]))
+    return !(s[1] == '?' || is_separator((unsigned char)s[1]));
+  return false;
+}
+
+// The Win32 API offers PathIsRelative, but it requires linking with shlwapi.
+// Rewriting a relative path is not too complex, unlike correct conversion of
+// Windows paths in general (https://googleprojectzero.blogspot.com/2016/02/).
+// Rooted paths, relative or not, unc and extended paths are never resolved
+// relative to the includer.
+nonnull((2,3))
+static int32_t resolve_path(
+  const char *includer, const char *include, char **path)
+{
+  // support relative non-rooted paths only
+  if (*includer && is_relative(include) && !is_rooted(include)) {
+    assert(!is_relative(includer));
+    const char *separator = include;
+    for (const char *p = include; *p; p++)
+      if (is_separator((unsigned char)*p))
+        separator = p;
+    if (separator - include > INT_MAX)
+      return ZONE_OUT_OF_MEMORY;
+    char buffer[16];
+    int offset = (int)(separator - includer);
+    int length = snprintf(
+      buffer, sizeof(buffer), "%.*s/%s", offset, includer, include);
+    if (length < 0)
+      return ZONE_OUT_OF_MEMORY;
+    char *absolute;
+    if (!(absolute = malloc(length + 1)))
+      return ZONE_OUT_OF_MEMORY;
+    (void)snprintf(
+      absolute, (size_t)length + 1, "%.*s/%s", offset, includer, include);
+    *path = _fullpath(NULL, absolute, 0);
+    free(absolute);
+  } else {
+    *path = _fullpath(NULL, include, 0);
+  }
+
+  if (*path)
+    return 0;
+  return (errno == ENOMEM) ? ZONE_OUT_OF_MEMORY : ZONE_NOT_A_FILE;
+}
+#else
+nonnull_all
+static int32_t resolve_path(
+  const char *includer, const char *include, char **path)
+{
+  if (*includer && *include != '/') {
+    assert(*includer == '/');
+    const char *separator = strrchr(includer, '/');
+    if (separator - include > INT_MAX)
+      return ZONE_OUT_OF_MEMORY;
+    char buffer[16];
+    int offset = (int)(separator - includer);
+    int length = snprintf(
+      buffer, sizeof(buffer), "%.*s/%s", offset, includer, include);
+    if (length < 0)
+      return ZONE_OUT_OF_MEMORY;
+    char *absolute;
+    if (!(absolute = malloc((size_t)length + 1)))
+      return ZONE_OUT_OF_MEMORY;
+    (void)snprintf(
+      absolute, (size_t)length + 1, "%.*s/%s", offset, includer, include);
+    *path = realpath(absolute, NULL);
+    free(absolute);
+  } else {
+    *path = realpath(include, NULL);
+  }
+
+  if (*path)
+    return 0;
+  return (errno == ENOMEM) ? ZONE_OUT_OF_MEMORY : ZONE_NOT_A_FILE;
+}
+#endif
+
+nonnull((1))
+static void close_file(
+  parser_t *parser, file_t *file)
+{
+  assert((file->name == not_a_file) == (file->path == not_a_file));
+
   const bool is_string = file->name == not_a_file || file->path == not_a_file;
 
-  (void)parser;
-  assert(!is_string || !file->handle);
+  assert(!is_string || file == &parser->first);
+  assert(!is_string || file->handle == NULL);
 
   if (file->buffer.data && !is_string)
     free(file->buffer.data);
@@ -275,40 +223,176 @@ void zone_close_file(
   if (file->handle)
     (void)fclose(file->handle);
   file->handle = NULL;
+}
+
+nonnull_all
+static void initialize_file(
+  parser_t *parser, file_t *file)
+{
+  const size_t size = offsetof(file_t, fields.head);
+  memset(file, 0, size);
+
+  if (file == &parser->first) {
+    file->includer = NULL;
+    memcpy(file->origin.octets,
+           parser->options.origin.octets,
+           parser->options.origin.length);
+    file->origin.length = parser->options.origin.length;
+    file->last_class = parser->options.default_class;
+    file->last_ttl = parser->options.default_ttl;
+  } else {
+    assert(parser->file);
+    file->includer = parser->file;
+    memcpy(&file->origin, &parser->file->origin, sizeof(file->origin));
+    // retain class and TTL
+    file->last_class = parser->file->last_class;
+    file->last_ttl = parser->file->last_ttl;
+  }
+
+  file->line = 1;
+  file->name = (char *)not_a_file;
+  file->path = (char *)not_a_file;
+  file->handle = NULL;
+  file->buffer.data = NULL;
+  file->start_of_line = true;
+  file->end_of_file = 1;
+  file->fields.tape[0] = NULL;
+  file->fields.head = file->fields.tail = file->fields.tape;
+  file->delimiters.tape[0] = NULL;
+  file->delimiters.head = file->delimiters.tail = file->delimiters.tape;
+  file->lines.tape[0] = 0;
+  file->lines.head = file->lines.tail = file->lines.tape;
+}
+
+nonnull_all
+static int32_t open_file(
+  parser_t *parser, file_t *file, const char *include, size_t length)
+{
+  int32_t code;
+  const size_t size = ZONE_WINDOW_SIZE + 1 + ZONE_PADDING_SIZE;
+
+  initialize_file(parser, file);
+
+  if (!(file->name = malloc(length + 1)))
+    return ZONE_OUT_OF_MEMORY;
+  memcpy(file->name, include, length);
+  file->name[length] = '\0';
+  if (!(file->buffer.data = malloc(size)))
+    return (void)close_file(parser, file), ZONE_OUT_OF_MEMORY;
+  file->buffer.data[0] = '\0';
+  file->buffer.size = ZONE_WINDOW_SIZE;
+  file->end_of_file = 0;
+  file->fields.tape[0] = &file->buffer.data[0];
+  file->fields.tape[1] = &file->buffer.data[0];
+
+  const char *includer = "";
   if (file != &parser->first)
-    free(file);
+    includer = parser->file->path;
+  if ((code = resolve_path(includer, file->name, &file->path)))
+    return (void)close_file(parser, file), code;
+
+  if ((file->handle = fopen(file->path, "rb")))
+    return 0;
+
+  switch (errno) {
+    case ENOMEM:
+      code = ZONE_OUT_OF_MEMORY;
+      break;
+    case EACCES:
+      code = ZONE_NOT_PERMITTED;
+      break;
+    default:
+      code = ZONE_NOT_A_FILE;
+      break;
+  }
+
+  close_file(parser, file);
+  return code;
+}
+
+diagnostic_pop()
+
+diagnostic_push()
+clang_diagnostic_ignored(missing-prototypes)
+
+nonnull((1))
+void zone_close_file(
+  parser_t *parser, zone_file_t *file)
+{
+  if (!file)
+    return;
+  close_file(parser, file);
+  free(file);
 }
 
 nonnull_all
 int32_t zone_open_file(
-  parser_t *parser, const char *path, size_t length, zone_file_t **fileptr)
+  parser_t *parser, const char *path, size_t length, zone_file_t **file)
 {
-  zone_file_t *file;
-  int32_t result;
+  int32_t code;
 
-  if (!(file = malloc(sizeof(*file))))
+  if (!(*file = malloc(sizeof(**file))))
     return ZONE_OUT_OF_MEMORY;
-  memset(file, 0, sizeof(*file));
-  if ((result = open_file(parser, file, path, length)) < 0)
-    goto err_open;
-
-  *fileptr = file;
+  if ((code = open_file(parser, *file, path, length)) < 0)
+    return (void)free(*file), code;
   return 0;
-err_open:
-  zone_close_file(parser, file);
-  return result;
 }
 
+nonnull_all
 void zone_close(parser_t *parser)
 {
-  if (!parser)
-    return;
-
+  assert(parser);
   for (zone_file_t *file = parser->file, *includer; file; file = includer) {
     includer = file->includer;
-    if (file->handle)
-      zone_close_file(parser, file);
+    close_file(parser, file);
+    if (file != &parser->first)
+      free(file);
   }
+}
+
+nonnull((1,2,3))
+static int32_t initialize_parser(
+  zone_parser_t *parser,
+  const zone_options_t *options,
+  zone_buffers_t *buffers,
+  void *user_data)
+{
+  if (!options->accept.callback)
+    return ZONE_BAD_PARAMETER;
+  if (!options->default_ttl)
+    return ZONE_BAD_PARAMETER;
+  if (!options->non_strict && options->default_ttl > INT32_MAX)
+    return ZONE_BAD_PARAMETER;
+  if (!options->origin.octets || !options->origin.length)
+    return ZONE_BAD_PARAMETER;
+
+  const uint8_t *root = &options->origin.octets[options->origin.length - 1];
+  if (root[0] != 0)
+    return ZONE_BAD_PARAMETER;
+  const uint8_t *label = &options->origin.octets[0];
+  while (label < root) {
+    if (root - label < label[0])
+      return ZONE_BAD_PARAMETER;
+    label += label[0] + 1;
+  }
+
+  if (label != root)
+    return ZONE_BAD_PARAMETER;
+
+  const size_t size = offsetof(parser_t, file);
+  memset(parser, 0, size);
+  parser->options = *options;
+  parser->user_data = user_data;
+  parser->file = &parser->first;
+  parser->buffers.size = buffers->size;
+  parser->buffers.owner.active = 0;
+  parser->buffers.owner.blocks = buffers->owner;
+  parser->buffers.rdata.active = 0;
+  parser->buffers.rdata.blocks = buffers->rdata;
+  parser->owner = &parser->buffers.owner.blocks[0];
+  parser->owner->length = 0;
+  parser->rdata = &parser->buffers.rdata.blocks[0];
+  return 0;
 }
 
 int32_t zone_open(
@@ -318,35 +402,13 @@ int32_t zone_open(
   const char *path,
   void *user_data)
 {
-  zone_file_t *file;
-  int32_t result;
+  int32_t code;
 
-  if ((result = check_options(options)) < 0)
-    return result;
-
-  memset(parser, 0, sizeof(*parser));
-  parser->options = *options;
-  parser->user_data = user_data;
-  file = parser->file = &parser->first;
-  if ((result = open_file(parser, file, path, strlen(path))) < 0)
-    goto error;
-  memcpy(file->origin.octets, options->origin.octets, options->origin.length);
-  file->origin.length = options->origin.length;
-  parser->buffers.size = buffers->size;
-  parser->buffers.owner.serial = 0;
-  parser->buffers.owner.blocks = buffers->owner;
-  parser->buffers.rdata.blocks = buffers->rdata;
-  file->owner = file->origin;
-  file->last_type = 0;
-  file->last_class = options->default_class;
-  file->last_ttl = options->default_ttl;
-  file->line = 1;
-
-  set_defaults(parser);
+  if ((code = initialize_parser(parser, options, buffers, user_data)) < 0)
+    return code;
+  if ((code = open_file(parser, &parser->first, path, strlen(path))) < 0)
+    return code;
   return 0;
-error:
-  zone_close(parser);
-  return result;
 }
 
 diagnostic_pop()
@@ -358,13 +420,13 @@ int32_t zone_parse(
   const char *path,
   void *user_data)
 {
-  int32_t result;
+  int32_t code;
 
-  if ((result = zone_open(parser, options, buffers, path, user_data)) < 0)
-    return result;
-  result = parse(parser, user_data);
+  if ((code = zone_open(parser, options, buffers, path, user_data)) < 0)
+    return code;
+  code = parse(parser, user_data);
   zone_close(parser);
-  return result;
+  return code;
 }
 
 int32_t zone_parse_string(
@@ -375,50 +437,23 @@ int32_t zone_parse_string(
   size_t length,
   void *user_data)
 {
-  zone_file_t *file;
-  int32_t result;
+  int32_t code;
 
+  if ((code = initialize_parser(parser, options, buffers, user_data)) < 0)
+    return code;
   if (!length || string[length] != '\0')
     return ZONE_BAD_PARAMETER;
-  if ((result = check_options(options)) < 0)
-    return result;
+  initialize_file(parser, parser->file);
+  parser->file->buffer.data = (char *)string;
+  parser->file->buffer.size = length;
+  parser->file->buffer.length = length;
+  parser->file->fields.tape[0] = &string[length];
+  parser->file->fields.tape[1] = &string[length];
+  assert(parser->file->end_of_file == 1);
 
-  memset(parser, 0, sizeof(*parser));
-  parser->options = *options;
-  parser->user_data = user_data;
-  file = parser->file = &parser->first;
-  memcpy(file->origin.octets, options->origin.octets, options->origin.length);
-  file->origin.length = options->origin.length;
-  file->name = (char *)not_a_file;
-  file->path = (char *)not_a_file;
-  file->handle = NULL;
-  file->buffer.index = 0;
-  file->buffer.length = length;
-  file->buffer.size = length;
-  file->buffer.data = (char *)string;
-  file->start_of_line = true;
-  file->end_of_file = 1;
-  file->fields.tape[0] = file->fields.tape[1] = &string[length];
-  file->fields.head = file->fields.tape;
-  file->fields.tail = file->fields.tape;
-  file->lines.tape[0] = 0;
-  file->lines.head = file->lines.tape;
-  file->lines.tail = file->lines.tape;
-
-  parser->buffers.size = buffers->size;
-  parser->buffers.owner.serial = 0;
-  parser->buffers.owner.blocks = buffers->owner;
-  parser->buffers.rdata.blocks = buffers->rdata;
-  file->owner = file->origin;
-  file->last_type = 0;
-  file->last_class = options->default_class;
-  file->last_ttl = options->default_ttl;
-  file->line = 1;
-
-  set_defaults(parser);
-  result = parse(parser, user_data);
+  code = parse(parser, user_data);
   zone_close(parser);
-  return result;
+  return code;
 }
 
 zone_nonnull((1,3))

--- a/tests/base32.c
+++ b/tests/base32.c
@@ -67,7 +67,7 @@ void base32_syntax(void **state)
 
   for (size_t i=0, n=sizeof(tests)/sizeof(tests[0]); i < n; i++) {
     char rr[256];
-    const char rrfmt[] = " NSEC3 1 1 12 aabbccdd ( %s A NS )";
+    const char rrfmt[] = "foo. NSEC3 1 1 12 aabbccdd ( %s A NS )";
     zone_parser_t parser = { 0 };
     zone_name_buffer_t name;
     zone_rdata_buffer_t rdata;

--- a/tests/ip4.c
+++ b/tests/ip4.c
@@ -89,7 +89,7 @@ void ipv4_syntax(void **state)
     zone_options_t options = { 0 };
     int32_t result;
 
-    (void)snprintf(rr, sizeof(rr), " A %s", tests[i].address);
+    (void)snprintf(rr, sizeof(rr), "foo. A %s", tests[i].address);
 
     options.accept.callback = add_rr;
     options.origin.octets = origin;

--- a/tests/syntax.c
+++ b/tests/syntax.c
@@ -565,6 +565,24 @@ static int32_t parse_as_include(const char *text, size_t *count)
 }
 
 /*!cmocka */
+void who_dis(void **state)
+{
+  (void)state;
+
+  int32_t code;
+  size_t count = 0;
+  static const char *dat = PAD(" TXT \"dat\"");
+  static const char *dis_n_dat = PAD("dis. TXT \"dis\"\n"
+                                     "     TXT \"dat\"");
+
+  code = parse(dat, &count);
+  assert_int_equal(code, ZONE_SYNTAX_ERROR);
+  code = parse(dis_n_dat, &count);
+  assert_int_equal(code, ZONE_SUCCESS);
+  assert_true(count == 2);
+}
+
+/*!cmocka */
 void quote_no_unquote(void **state)
 {
   (void)state;

--- a/tests/syntax.c
+++ b/tests/syntax.c
@@ -635,33 +635,6 @@ void no_famous_last_words(void **state)
 }
 
 /*!cmocka */
-void been_there_done_that(void **state)
-{
-  (void)state;
-
-  int32_t code;
-  size_t count = 0;
-
-  char *path = generate_include(" ");
-  assert_non_null(path);
-  FILE* handle = fopen(path, "wb");
-  assert_non_null(handle);
-  char dummy[16];
-  int length = snprintf(dummy, sizeof(dummy), "$INCLUDE \"%s\"\n", path);
-  assert_true(length > 0 && length < INT_MAX - ZONE_PADDING_SIZE);
-  char *include = malloc((size_t)length + 1 + ZONE_PADDING_SIZE);
-  assert_non_null(include);
-  (void)snprintf(include, (size_t)length + 1, "$INCLUDE \"%s\"\n", path);
-  int result = fputs(include, handle);
-  assert_true(result >= 0);
-  (void)fclose(handle);
-  free(path);
-  code = parse(include, &count);
-  free(include);
-  assert_int_equal(code, ZONE_SYNTAX_ERROR);
-}
-
-/*!cmocka */
 void bad_a_rrs(void **state)
 {
   (void)state;

--- a/tests/syntax.c
+++ b/tests/syntax.c
@@ -617,29 +617,6 @@ void no_famous_last_words(void **state)
 }
 
 /*!cmocka */
-void the_include_that_wasnt(void **state)
-{
-  (void)state;
-
-  int32_t code;
-  size_t count = 0;
-
-  char *path = generate_include(" ");
-  assert_non_null(path);
-  char dummy[16];
-  int length = snprintf(dummy, sizeof(dummy), "$INCLUDE \"%s\"\n", path);
-  assert_true(length > 0 && length < INT_MAX - ZONE_PADDING_SIZE);
-  char *include = malloc((size_t)length + 1 + ZONE_PADDING_SIZE);
-  assert_non_null(include);
-  (void)snprintf(include, (size_t)length + 1, "$INCLUDE \"%s\"\n", path);
-  remove_include(path);
-  free(path);
-  code = parse(include, &count);
-  free(include);
-  assert_int_equal(code, ZONE_READ_ERROR);
-}
-
-/*!cmocka */
 void been_there_done_that(void **state)
 {
   (void)state;

--- a/tests/types.c
+++ b/tests/types.c
@@ -47,42 +47,42 @@ struct rdata {
 };
 
 static const char a_text[] =
-  PAD(" A 192.0.2.1");
+  PAD("foo. A 192.0.2.1");
 static const char a_generic_text[] =
-  PAD(" A \\# 4 c0000201");
+  PAD("foo. A \\# 4 c0000201");
 static const rdata_t a_rdata =
   RDATA(0xc0, 0x00, 0x02, 0x01);
 
 static const char ns_text[] =
-  PAD(" NS host.example.com.");
+  PAD("foo. NS host.example.com.");
 static const char ns_generic_text[] =
-  PAD(" NS \\# 18 04686f7374076578616d706c6503636f6d00");
+  PAD("foo. NS \\# 18 04686f7374076578616d706c6503636f6d00");
 static const rdata_t ns_rdata =
   RDATA(HOST_EXAMPLE_COM);
 
 static const char md_text[] =
-  PAD(" MD host.example.com.");
+  PAD("foo. MD host.example.com.");
 static const char md_generic_text[] =
-  PAD(" MD \\# 18 04686f7374076578616d706c6503636f6d00");
+  PAD("foo. MD \\# 18 04686f7374076578616d706c6503636f6d00");
 static const char mf_text[] =
-  PAD(" MF host.example.com.");
+  PAD("foo. MF host.example.com.");
 static const char mf_generic_text[] =
-  PAD(" MF \\# 18 04686f7374076578616d706c6503636f6d00");
+  PAD("foo. MF \\# 18 04686f7374076578616d706c6503636f6d00");
 static const char cname_text[] =
-  PAD(" CNAME host.example.com.");
+  PAD("foo. CNAME host.example.com.");
 static const char cname_generic_text[] =
-  PAD(" CNAME \\# 18 04686f7374076578616d706c6503636f6d00");
+  PAD("foo. CNAME \\# 18 04686f7374076578616d706c6503636f6d00");
 
 static const char soa_text[] =
-  PAD(" SOA host.example.com. hostmaster.example.com. 2023063001 1 2 3 4");
+  PAD("foo. SOA host.example.com. hostmaster.example.com. 2023063001 1 2 3 4");
 static const char soa_generic_text[] =
-  PAD(" SOA \\# 62 04686f7374076578616d706c6503636f6d00"
-      "            0a686f73746d6173746572076578616d706c6503636f6d00"
-      "            78957dd9"
-      "            00000001"
-      "            00000002"
-      "            00000003"
-      "            00000004");
+  PAD("foo. SOA \\# 62 04686f7374076578616d706c6503636f6d00"
+      "                0a686f73746d6173746572076578616d706c6503636f6d00"
+      "                78957dd9"
+      "                00000001"
+      "                00000002"
+      "                00000003"
+      "                00000004");
 static const rdata_t soa_rdata =
   RDATA(/* host.example.com. */
         HOST_EXAMPLE_COM,
@@ -101,29 +101,29 @@ static const rdata_t soa_rdata =
       );
 
 static const char mb_text[] =
-  PAD(" MB host.example.com.");
+  PAD("foo. MB host.example.com.");
 static const char mb_generic_text[] =
-  PAD(" MB \\# 18 04686f7374076578616d706c6503636f6d00");
+  PAD("foo. MB \\# 18 04686f7374076578616d706c6503636f6d00");
 
 static const char mg_text[] =
-  PAD(" MG hostmaster.example.com.");
+  PAD("foo. MG hostmaster.example.com.");
 static const char mg_generic_text[] =
-  PAD(" MG \\# 24 0a686f73746d6173746572076578616d706c6503636f6d00");
+  PAD("foo. MG \\# 24 0a686f73746d6173746572076578616d706c6503636f6d00");
 static const rdata_t mg_rdata = RDATA(HOSTMASTER_EXAMPLE_COM);
 
 static const char mr_text[] =
-  PAD(" MR hostmaster.example.com.");
+  PAD("foo. MR hostmaster.example.com.");
 static const char mr_generic_text[] =
-  PAD(" MR \\# 24 0a686f73746d6173746572076578616d706c6503636f6d00");
+  PAD("foo. MR \\# 24 0a686f73746d6173746572076578616d706c6503636f6d00");
 static const char ptr_text[] =
-  PAD(" PTR host.example.com.");
+  PAD("foo. PTR host.example.com.");
 static const char ptr_generic_text[] =
-  PAD(" PTR \\# 18 04686f7374076578616d706c6503636f6d00");
+  PAD("foo. PTR \\# 18 04686f7374076578616d706c6503636f6d00");
 
 static const char wks_text[] =
-  PAD(" WKS 192.0.2.1 tcp 0 tcpmux");
+  PAD("foo. WKS 192.0.2.1 tcp 0 tcpmux");
 static const char wks_generic_text[] =
-  PAD(" TYPE11 \\# 6 c0000201 06 c0");
+  PAD("foo. TYPE11 \\# 6 c0000201 06 c0");
 static const rdata_t wks_rdata =
   RDATA(/* address */
         0xc0, 0x00, 0x02, 0x01,
@@ -133,9 +133,9 @@ static const rdata_t wks_rdata =
         0xc0);
 
 static const char hinfo_text[] =
-  PAD(" HINFO amd64 linux");
+  PAD("foo. HINFO amd64 linux");
 static const char hinfo_generic_text[] =
-  PAD(" HINFO \\# 12 05616d643634 056c696e7578");
+  PAD("foo. HINFO \\# 12 05616d643634 056c696e7578");
 static const rdata_t hinfo_rdata =
   RDATA(/* amd64 */
         5, 'a', 'm', 'd', '6', '4',
@@ -143,17 +143,17 @@ static const rdata_t hinfo_rdata =
         5, 'l', 'i', 'n', 'u', 'x');
 
 static const char minfo_text[] =
-  PAD(" MINFO hostmaster.example.com. hostmaster.example.com.");
+  PAD("foo. MINFO hostmaster.example.com. hostmaster.example.com.");
 static const char minfo_generic_text[] =
-  PAD(" MINFO \\# 48 0a686f73746d6173746572076578616d706c6503636f6d00"
-      "              0a686f73746d6173746572076578616d706c6503636f6d00");
+  PAD("foo. MINFO \\# 48 0a686f73746d6173746572076578616d706c6503636f6d00"
+      "                  0a686f73746d6173746572076578616d706c6503636f6d00");
 static const rdata_t minfo_rdata =
   RDATA(HOSTMASTER_EXAMPLE_COM, HOSTMASTER_EXAMPLE_COM);
 
 static const char mx_text[] =
-  PAD(" MX 10 host.example.com.");
+  PAD("foo. MX 10 host.example.com.");
 static const char mx_generic_text[] =
-  PAD(" MX \\# 20 000a 04686f7374076578616d706c6503636f6d00");
+  PAD("foo. MX \\# 20 000a 04686f7374076578616d706c6503636f6d00");
 static const rdata_t mx_rdata =
   RDATA(/* 10 */
         0x00, 0x0a,
@@ -161,9 +161,9 @@ static const rdata_t mx_rdata =
         HOST_EXAMPLE_COM);
 
 static const char txt_text[] =
-  PAD(" TXT example of TXT rdata");
+  PAD("foo. TXT example of TXT rdata");
 static const char txt_generic_text[] =
-  PAD(" TXT \\# 21 076578616d706c65 026f66 03545854 057264617461");
+  PAD("foo. TXT \\# 21 076578616d706c65 026f66 03545854 057264617461");
 static const rdata_t txt_rdata =
   RDATA(/* example */
         0x07, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65,
@@ -175,17 +175,17 @@ static const rdata_t txt_rdata =
         0x05, 0x72, 0x64, 0x61, 0x74, 0x61);
 
 static const char rp_text[] =
-  PAD(" RP hostmaster.example.com. host.example.com.");
+  PAD("foo. RP hostmaster.example.com. host.example.com.");
 static const char rp_generic_text[] =
-  PAD(" RP \\# 42 0a686f73746d6173746572076578616d706c6503636f6d00"
-      "           04686f7374076578616d706c6503636f6d00");
+  PAD("foo. RP \\# 42 0a686f73746d6173746572076578616d706c6503636f6d00"
+      "               04686f7374076578616d706c6503636f6d00");
 static const rdata_t rp_rdata =
   RDATA(HOSTMASTER_EXAMPLE_COM, HOST_EXAMPLE_COM);
 
 static const char afsdb_text[] =
-  PAD(" AFSDB 1 host.example.com.");
+  PAD("foo. AFSDB 1 host.example.com.");
 static const char afsdb_generic_text[] =
-  PAD(" AFSDB \\# 20 0001 04686f7374076578616d706c6503636f6d00");
+  PAD("foo. AFSDB \\# 20 0001 04686f7374076578616d706c6503636f6d00");
 static const rdata_t afsdb_rdata =
   RDATA(/* 1 */
         0x00, 0x01,
@@ -193,26 +193,26 @@ static const rdata_t afsdb_rdata =
         HOST_EXAMPLE_COM);
 
 static const char x25_text[] =
-  PAD(" X25 311061700956");
+  PAD("foo. X25 311061700956");
 static const char x25_generic_text[] =
-  PAD(" X25 \\# 13 0c333131303631373030393536");
+  PAD("foo. X25 \\# 13 0c333131303631373030393536");
 static const rdata_t x25_rdata =
   RDATA(0x0c, 0x33, 0x31, 0x31, 0x30, 0x36, 0x31, 0x37,
         0x30, 0x30, 0x39, 0x35, 0x36);
 
 static const char isdn_text[] =
-  PAD(" ISDN 150862028003217 004");
+  PAD("foo. ISDN 150862028003217 004");
 static const char isdn_generic_text[] =
-  PAD(" ISDN \\# 20 0f313530383632303238303033323137 03303034");
+  PAD("foo. ISDN \\# 20 0f313530383632303238303033323137 03303034");
 static const rdata_t isdn_rdata =
   RDATA(0x0f, 0x31, 0x35, 0x30, 0x38, 0x36, 0x32, 0x30,
         0x32, 0x38, 0x30, 0x30, 0x33, 0x32, 0x31, 0x37,
         0x03, 0x30, 0x30, 0x34);
 
 static const char rt_text[] =
-  PAD(" RT 10 relay.example.com.");
+  PAD("foo. RT 10 relay.example.com.");
 static const char rt_generic_text[] =
-  PAD(" RT \\# 21 000a 0572656c6179076578616d706c6503636f6d00");
+  PAD("foo. RT \\# 21 000a 0572656c6179076578616d706c6503636f6d00");
 static const rdata_t rt_rdata =
   RDATA(/* 10 */
         0x00, 0x0a,
@@ -222,9 +222,9 @@ static const rdata_t rt_rdata =
         0x6f, 0x6d, 0x00);
 
 static const char nsap_text[] =
-  PAD(" NSAP 0x47.0005.80.005a00.0000.0001.e133.aaaaaa000111.00");
+  PAD("foo. NSAP 0x47.0005.80.005a00.0000.0001.e133.aaaaaa000111.00");
 static const char nsap_generic_text[] =
-  PAD(" TYPE22 \\# 20 47 0005 80 005a00 0000 0001 e133 aaaaaa000111 00");
+  PAD("foo. TYPE22 \\# 20 47 0005 80 005a00 0000 0001 e133 aaaaaa000111 00");
 static const rdata_t nsap_rdata =
   RDATA(0x47, 0x00, 0x05, 0x80, 0x00, 0x5a, 0x00, 0x00,
         0x00, 0x00, 0x01, 0xe1, 0x33, 0xaa, 0xaa, 0xaa,
@@ -265,14 +265,14 @@ static const rdata_t sig_rdata =
         0xe0, 0xbc, 0x69, 0x3a, 0xce, 0xf8, 0xa2, 0xa6, 0x09, 0xa6);
 
 static const char key_text[] =
-  PAD(" KEY 0 0 0 Zm9vYmFy");
+  PAD("foo. KEY 0 0 0 Zm9vYmFy");
 static const char key_generic_text[] =
-  PAD(" KEY \\# 10 00000000666f6f626172");
+  PAD("foo. KEY \\# 10 00000000666f6f626172");
 static const rdata_t key_rdata =
   RDATA(0x00, 0x00, 0x00, 0x00, 0x66, 0x6f, 0x6f, 0x62, 0x61, 0x72);
 
 static const char gpos_text[] =
-  PAD(" GPOS -32.6882 116.8652 10.0");
+  PAD("foo. GPOS -32.6882 116.8652 10.0");
 static const rdata_t gpos_rdata =
   RDATA(/* latitude */
         8, '-', '3', '2', '.', '6', '8', '8', '2',
@@ -314,14 +314,14 @@ static const rdata_t nxt_rdata =
         0x40, 0x01, 0x00, 0x82);
 
 static const char naptr_text[] =
-  PAD(" NAPTR 100 50 \"s\" \"http+I2L+I2C+I2R\" \"\"  _http._tcp.gatech.edu.");
+  PAD("foo. NAPTR 100 50 \"s\" \"http+I2L+I2C+I2R\" \"\"  _http._tcp.gatech.edu.");
 static const char naptr_generic_text[] =
-  PAD(" NAPTR \\# 47 0064"
-      "              0032"
-      "              0173"
-      "              10687474702b49324c2b4932432b493252"
-      "              00"
-      "              055f68747470045f746370066761746563680365647500");
+  PAD("foo. NAPTR \\# 47 0064"
+      "                  0032"
+      "                  0173"
+      "                  10687474702b49324c2b4932432b493252"
+      "                  00"
+      "                  055f68747470045f746370066761746563680365647500");
 static const rdata_t naptr_rdata =
   RDATA(/* order */
         0x00, 0x64,
@@ -341,14 +341,14 @@ static const rdata_t naptr_rdata =
         0x63, 0x68, 0x03, 0x65, 0x64, 0x75, 0x00);
 
 static const char kx_text[] =
-  PAD(" KX 10 kx-host");
+  PAD("foo. KX 10 kx-host");
 static const char kx_generic_text[] =
-  PAD(" KX \\# 23 000a 076b782d686f7374076578616d706c6503636f6d00");
+  PAD("foo. KX \\# 23 000a 076b782d686f7374076578616d706c6503636f6d00");
 static const rdata_t kx_rdata =
   RDATA(0x00, 0x0a, 0x07, 0x6b, 0x78, 0x2d, 0x68, 0x6f, 0x73, 0x74, EXAMPLE_COM);
 
 static const char cert_text[] =
-  PAD(" CERT PKIX 65535 RSASHA256 Zm9vYmFy");
+  PAD("foo. CERT PKIX 65535 RSASHA256 Zm9vYmFy");
 static const rdata_t cert_rdata =
   RDATA(/* type */
         0x00, 0x01,
@@ -359,9 +359,9 @@ static const rdata_t cert_rdata =
         /* certificate */
         0x66, 0x6F, 0x6F, 0x62, 0x61, 0x72);
 
-static const char dname_text[] = PAD(" DNAME host.example.com.");
+static const char dname_text[] = PAD("foo. DNAME host.example.com.");
 static const char dname_generic_text[] =
-  PAD(" DNAME \\# 18 04686f7374076578616d706c6503636f6d00");
+  PAD("foo. DNAME \\# 18 04686f7374076578616d706c6503636f6d00");
 static const rdata_t dname_rdata = RDATA(HOST_EXAMPLE_COM);
 
 static const char apl_text[] =
@@ -373,13 +373,13 @@ static const rdata_t apl_rdata =
         0, 1, 28, 0x84, 192, 168, 38, 0);
 
 static const char sshfp_text[] =
-  PAD(" SSHFP 4 2 123456789abcdef67890123456789abcdef67890123456789abcdef123456789");
+  PAD("foo. SSHFP 4 2 123456789abcdef67890123456789abcdef67890123456789abcdef123456789");
 static const char sshfp_generic_text[] =
-  PAD(" SSHFP \\# 34 04 02"
-      "           123456789abcdef6"
-      "           7890123456789abc"
-      "           def6789012345678"
-      "           9abcdef123456789");
+  PAD("foo. SSHFP \\# 34 04 02"
+      "               123456789abcdef6"
+      "               7890123456789abc"
+      "               def6789012345678"
+      "               9abcdef123456789");
 static const rdata_t sshfp_rdata =
   RDATA(/* algorithm */
         0x04,
@@ -502,11 +502,11 @@ static const rdata_t nsec3_no_data_rdata =
 
 // https://www.rfc-editor.org/rfc/rfc4701.html#section-3.6.1
 static const char dhcid_text[] =
-  PAD(" DHCID   ( AAIBY2/AuCccgoJbsaxcQc9TUapptP69l"
-      "           OjxfNuVAA2kjEA= )");
+  PAD("foo. DHCID   ( AAIBY2/AuCccgoJbsaxcQc9TUapptP69l"
+      "               OjxfNuVAA2kjEA= )");
 static const char dhcid_generic_text[] =
-  PAD(" DHCID \\# 35 ( 000201636fc0b8271c82825bb1ac5c41cf5351aa69b4febd94e8f17cd"
-      "          b95000da48c40 )");
+  PAD("foo. DHCID \\# 35 ( 000201636fc0b8271c82825bb1ac5c41cf5351aa69b4febd94e8f17cd"
+      "                    b95000da48c40 )");
 static const rdata_t dhcid_rdata =
   RDATA(0x00, 0x02, 0x01, 0x63, 0x6f, 0xc0, 0xb8, 0x27,
         0x1c, 0x82, 0x82, 0x5b, 0xb1, 0xac, 0x5c, 0x41,
@@ -515,10 +515,10 @@ static const rdata_t dhcid_rdata =
         0xa4, 0x8c, 0x40);
 
 static const char tlsa_text[] =
-  PAD(" TLSA 0 0 1 d2abde240d7cd3ee6b4b28c54df034b97983a1d16e8a410e4561cb106618e971");
+  PAD("foo. TLSA 0 0 1 d2abde240d7cd3ee6b4b28c54df034b97983a1d16e8a410e4561cb106618e971");
 static const char tlsa_generic_text[] =
-  PAD(" TLSA \\# 35 00 00 01 ( d2abde240d7cd3ee6b4b28c54df034b9"
-      "                        7983a1d16e8a410e4561cb106618e971 )");
+  PAD("foo. TLSA \\# 35 00 00 01 ( d2abde240d7cd3ee6b4b28c54df034b9"
+      "                            7983a1d16e8a410e4561cb106618e971 )");
 static const rdata_t tlsa_rdata =
   RDATA(/* usage */
         0x00,
@@ -533,10 +533,10 @@ static const rdata_t tlsa_rdata =
         0x45, 0x61, 0xcb, 0x10, 0x66, 0x18, 0xe9, 0x71);
 
 static const char smimea_text[] =
-  PAD(" SMIMEA 0 0 1 d2abde240d7cd3ee6b4b28c54df034b97983a1d16e8a410e4561cb106618e971");
+  PAD("foo. SMIMEA 0 0 1 d2abde240d7cd3ee6b4b28c54df034b97983a1d16e8a410e4561cb106618e971");
 static const char smimea_generic_text[] =
-  PAD(" SMIMEA \\# 35 00 00 01 ( d2abde240d7cd3ee6b4b28c54df034b9"
-      "                          7983a1d16e8a410e4561cb106618e971 )");
+  PAD("foo. SMIMEA \\# 35 00 00 01 ( d2abde240d7cd3ee6b4b28c54df034b9"
+      "                              7983a1d16e8a410e4561cb106618e971 )");
 static const rdata_t smimea_rdata =
   RDATA(/* usage */
         0x00,
@@ -587,9 +587,9 @@ static const rdata_t hip_rdata =
         );
 
 static const char cds_text[] =
-  PAD(" CDS 58470 5 1 ( 3079F1593EBAD6DC121E202A8B766A6A4837206C )");
+  PAD("foo. CDS 58470 5 1 ( 3079F1593EBAD6DC121E202A8B766A6A4837206C )");
 static const char cds_generic_text[] =
-  PAD(" CDS \\# 24 e466 05 01 3079f1593ebad6dc121e202a8b766a6a4837206c");
+  PAD("foo. CDS \\# 24 e466 05 01 3079f1593ebad6dc121e202a8b766a6a4837206c");
 static const rdata_t cds_rdata =
   RDATA(0xe4, 0x66,
         0x05,
@@ -599,32 +599,32 @@ static const rdata_t cds_rdata =
         0x48, 0x37, 0x20, 0x6c);
 
 static const char cdnskey_text[] =
-  PAD(" CDNSKEY 256 3 5 ( AQPSKmynfzW4kyBv015MUG2DeIQ3"
-      "                   Cbl+BBZH4b/0PY1kxkmvHjcZc8no"
-      "                   kfzj31GajIQKY+5CptLr3buXA10h"
-      "                   WqTkF7H6RfoRqXQeogmMHfpftf6z"
-      "                   Mv1LyBUgia7za6ZEzOJBOztyvhjL"
-      "                   742iU/TpPSEDhm2SNKLijfUppn1U"
-      "                   aNvv4w== )");
+  PAD("foo. CDNSKEY 256 3 5 ( AQPSKmynfzW4kyBv015MUG2DeIQ3"
+      "                       Cbl+BBZH4b/0PY1kxkmvHjcZc8no"
+      "                       kfzj31GajIQKY+5CptLr3buXA10h"
+      "                       WqTkF7H6RfoRqXQeogmMHfpftf6z"
+      "                       Mv1LyBUgia7za6ZEzOJBOztyvhjL"
+      "                       742iU/TpPSEDhm2SNKLijfUppn1U"
+      "                       aNvv4w== )");
 static const char cdnskey_generic_text[] = PAD(
-  " CDNSKEY \\# 134 0100 03 05"
-  " 0103d22a6ca77f35"
-  " b893206fd35e4c50"
-  " 6d8378843709b97e"
-  " 041647e1bff43d8d"
-  " 64c649af1e371973"
-  " c9e891fce3df519a"
-  " 8c840a63ee42a6d2"
-  " ebddbb97035d215a"
-  " a4e417b1fa45fa11"
-  " a9741ea2098c1dfa"
-  " 5fb5feb332fd4bc8"
-  " 152089aef36ba644"
-  " cce2413b3b72be18"
-  " cbef8da253f4e93d"
-  " 2103866d9234a2e2"
-  " 8df529a67d5468db"
-  " efe3"
+  "foo. CDNSKEY \\# 134 0100 03 05"
+  "     0103d22a6ca77f35"
+  "     b893206fd35e4c50"
+  "     6d8378843709b97e"
+  "     041647e1bff43d8d"
+  "     64c649af1e371973"
+  "     c9e891fce3df519a"
+  "     8c840a63ee42a6d2"
+  "     ebddbb97035d215a"
+  "     a4e417b1fa45fa11"
+  "     a9741ea2098c1dfa"
+  "     5fb5feb332fd4bc8"
+  "     152089aef36ba644"
+  "     cce2413b3b72be18"
+  "     cbef8da253f4e93d"
+  "     2103866d9234a2e2"
+  "     8df529a67d5468db"
+  "     efe3"
 );
 static const rdata_t cdnskey_rdata =
   RDATA(/* flags */
@@ -781,58 +781,58 @@ static const rdata_t svcb_rdata =
         0x00, 0x00, 0x00, 0x02, 0x00, 0x10, 0x00, 0x10, 0x00, 0x00);
 
 static const char spf_text[] =
-  PAD(" SPF \"v=spf1 +all\"");
+  PAD("foo. SPF \"v=spf1 +all\"");
 static const char spf_generic_text[] =
-  PAD(" SPF \\# 12 0b763d73706631202b616c6c");
+  PAD("foo. SPF \\# 12 0b763d73706631202b616c6c");
 static const rdata_t spf_rdata =
   RDATA(0x0b, 'v', '=', 's', 'p', 'f', '1', ' ', '+', 'a', 'l', 'l');
 
 static const char nid_text[] =
-  PAD(" NID 10 0014:4fff:ff20:ee64");
+  PAD("foo. NID 10 0014:4fff:ff20:ee64");
 static const char nid_generic_text[] =
-  PAD(" TYPE104 \\# 10 000a 0014 4fff ff20 ee64");
+  PAD("foo. TYPE104 \\# 10 000a 0014 4fff ff20 ee64");
 static const rdata_t nid_rdata =
   RDATA(0x00, 0x0a, 0x00, 0x14, 0x4f, 0xff, 0xff, 0x20, 0xee, 0x64);
 
 static const char l32_text[] =
-  PAD(" L32 10 10.1.2.0");
+  PAD("foo. L32 10 10.1.2.0");
 static const char l32_generic_text[] =
-  PAD(" L32 \\# 6 000a 0a010200");
+  PAD("foo. L32 \\# 6 000a 0a010200");
 static const rdata_t l32_rdata =
   RDATA(0x00, 0x0a, 0x0a, 0x01, 0x02, 0x00);
 
 static const char l64_text[] =
-  PAD(" L64 10 2001:0DB8:1140:1000");
+  PAD("foo. L64 10 2001:0DB8:1140:1000");
 static const char l64_generic_text[] =
-  PAD(" L64 \\# 10 000a 20010db811401000");
+  PAD("foo. L64 \\# 10 000a 20010db811401000");
 static const rdata_t l64_rdata =
   RDATA(0x00, 0x0a, 0x20, 0x01, 0x0d, 0xb8, 0x11, 0x40, 0x10, 0x00);
 
 static const char lp_text[] =
-  PAD(" LP 10 l64-subnet1.example.com.");
+  PAD("foo. LP 10 l64-subnet1.example.com.");
 static const char lp_generic_text[] =
-  PAD(" LP \\# 27 000a 0b6c36342d7375626e657431076578616d706c6503636f6d00");
+  PAD("foo. LP \\# 27 000a 0b6c36342d7375626e657431076578616d706c6503636f6d00");
 static const rdata_t lp_rdata =
   RDATA(0x00, 0x0a, 11, 'l', '6', '4', '-', 's', 'u', 'b', 'n', 'e', 't', '1', EXAMPLE_COM);
 
 static const char eui48_text[] =
-  PAD(" EUI48 00-00-5e-00-53-2a");
+  PAD("foo. EUI48 00-00-5e-00-53-2a");
 static const char eui48_generic_text[] =
-  PAD(" EUI48 \\# 6 00005e00532a");
+  PAD("foo. EUI48 \\# 6 00005e00532a");
 static const rdata_t eui48_rdata =
   RDATA(0x00, 0x00, 0x5e, 0x00, 0x53, 0x2a);
 
 static const char eui64_text[] =
-  PAD(" EUI64 00-00-5e-ef-10-00-00-2a");
+  PAD("foo. EUI64 00-00-5e-ef-10-00-00-2a");
 static const char eui64_generic_text[] =
-  PAD(" EUI64 \\# 8 00005eef1000002a");
+  PAD("foo. EUI64 \\# 8 00005eef1000002a");
 static const rdata_t eui64_rdata =
   RDATA(0x00, 0x00, 0x5e, 0xef, 0x10, 0x00, 0x00, 0x2a);
 
 static const char uri_text[] =
-  PAD(" URI 10 1 \"ftp://ftp1.example.com/public\"");
+  PAD("foo. URI 10 1 \"ftp://ftp1.example.com/public\"");
 static const char uri_generic_text[] =
-  PAD(" URI \\# 33 000a 0001 6674703a2f2f667470312e6578616d706c652e636f6d2f7075626c6963");
+  PAD("foo. URI \\# 33 000a 0001 6674703a2f2f667470312e6578616d706c652e636f6d2f7075626c6963");
 static const rdata_t uri_rdata =
   RDATA(0x00, 0x0a, 0x00, 0x01, 'f', 't', 'p', ':', '/', '/',
         'f', 't', 'p', '1', '.', 'e', 'x',
@@ -841,9 +841,9 @@ static const rdata_t uri_rdata =
         'i', 'c' );
 
 static const char caa_text[] =
-  PAD(" CAA 0 issue \"ca1.example.net\"");
+  PAD("foo. CAA 0 issue \"ca1.example.net\"");
 static const char caa_generic_text[] =
-  PAD(" CAA \\# 22 00 056973737565 6361312e6578616d706c652e6e6574");
+  PAD("foo. CAA \\# 22 00 056973737565 6361312e6578616d706c652e6e6574");
 static const rdata_t caa_rdata =
   RDATA(/* flags */
         0,
@@ -853,9 +853,9 @@ static const rdata_t caa_rdata =
         'c', 'a', '1', '.', 'e', 'x', 'a', 'm', 'p', 'l', 'e', '.', 'n', 'e', 't');
 
 static const char avc_text[] =
-  PAD(" AVC \"app-name:WOLFGANG|app-class:OAM\"");
+  PAD("foo. AVC \"app-name:WOLFGANG|app-class:OAM\"");
 static const char avc_generic_text[] =
-  PAD(" AVC \\# 32 1f6170702d6e616d653a574f4c4647414e477c6170702d636c6173733a4f414d");
+  PAD("foo. AVC \\# 32 1f6170702d6e616d653a574f4c4647414e477c6170702d636c6173733a4f414d");
 static const rdata_t avc_rdata =
   RDATA(31, 'a', 'p', 'p', '-', 'n', 'a', 'm', 'e',
             ':', 'W', 'O', 'L', 'F', 'G', 'A', 'N',
@@ -863,9 +863,9 @@ static const rdata_t avc_rdata =
             'a', 's', 's', ':', 'O', 'A', 'M');
 
 static const char dlv_text[] =
-  PAD(" DLV 58470 5 1 ( 3079F1593EBAD6DC121E202A8B766A6A4837206C )");
+  PAD("foo. DLV 58470 5 1 ( 3079F1593EBAD6DC121E202A8B766A6A4837206C )");
 static const char dlv_generic_text[] =
-  PAD(" DLV \\# 24 e466 05 01 3079f1593ebad6dc121e202a8b766a6a4837206c");
+  PAD("foo. DLV \\# 24 e466 05 01 3079f1593ebad6dc121e202a8b766a6a4837206c");
 
 typedef struct test test_t;
 struct test {


### PR DESCRIPTION
* Add buffer limit to avoid hogging all memory on malicious inputs.
* Drop use of PathIsRelative to remove dependency on shlwapi.
* Always allocate size+padding.
* Log an error if $INCLUDE is unsuccessful.