### PR TITLE
Make NSD work

### DIFF
--- a/FORMAT.md
+++ b/FORMAT.md
@@ -235,3 +235,5 @@ anything other than domain names and text strings, MUST not be quoted.
 * Some implementations (Knot, possibly PowerDNS) will silently split-up
   strings longer than 255 characters. Others (BIND, simdzone) will throw a
   syntax error.
+
+* Leading zeroes in integers appear to be allowed judging by the zone file generated for the [socket10kxfr](https://github.com/NLnetLabs/nsd/blob/86a6961f2ca64f169d7beece0ed8a5e1dd1cd302/tpkg/long/socket10kxfr.tdir/socket10kxfr.pre#L64) test in NSD. BIND and Knot (and the old parser in NSD) all parsed it without problems.

--- a/include/zone.h
+++ b/include/zone.h
@@ -461,9 +461,9 @@ zone_nonnull((1,2))
 zone_format_printf(2,3)
 zone_error(zone_parser_t *parser, const char *format, ...)
 {
+  va_list arguments;
   if (!(ZONE_ERROR & ~parser->options.log.mask))
     return;
-  va_list arguments;
   va_start(arguments, format);
   zone_vlog(parser, ZONE_ERROR, format, arguments);
   va_end(arguments);
@@ -474,9 +474,9 @@ zone_nonnull((1,2))
 zone_format_printf(2,3)
 zone_warning(zone_parser_t *parser, const char *format, ...)
 {
+  va_list arguments;
   if (!(ZONE_WARNING & ~parser->options.log.mask))
     return;
-  va_list arguments;
   va_start(arguments, format);
   zone_vlog(parser, ZONE_WARNING, format, arguments);
   va_end(arguments);
@@ -487,9 +487,9 @@ zone_nonnull((1,2))
 zone_format_printf(2,3)
 zone_info(zone_parser_t *parser, const char *format, ...)
 {
+  va_list arguments;
   if (!(ZONE_INFO & ~parser->options.log.mask))
     return;
-  va_list arguments;
   va_start(arguments, format);
   zone_vlog(parser, ZONE_INFO, format, arguments);
   va_end(arguments);

--- a/src/generic/number.h
+++ b/src/generic/number.h
@@ -15,10 +15,8 @@ static really_inline int32_t scan_int8(
 {
   uint32_t sum = (uint8_t)data[0] - '0';
 
-  if (sum > 9 || length > 3)
+  if (sum > 9 || !length || length > 3)
     return 0;
-
-  uint32_t non_zero = (sum != 0) | (length == 1);
 
   for (size_t count=1; count < length; count++) {
     const uint8_t digit = (uint8_t)data[count] - '0';
@@ -28,7 +26,7 @@ static really_inline int32_t scan_int8(
   }
 
   *number = (uint8_t)sum;
-  return sum <= 255u && non_zero;
+  return sum <= 255u;
 }
 
 nonnull((1,3))
@@ -37,10 +35,8 @@ static really_inline int32_t scan_int16(
 {
   uint32_t sum = (uint8_t)data[0] - '0';
 
-  if (sum > 9 || length > 5)
+  if (sum > 9 || !length || length > 5)
     return 0;
-
-  uint32_t non_zero = (sum != 0) | (length == 1);
 
   for (size_t count=1; count < length; count++) {
     const uint8_t digit = (uint8_t)data[count] - '0';
@@ -50,7 +46,7 @@ static really_inline int32_t scan_int16(
   }
 
   *number = (uint16_t)sum;
-  return sum <= 65535u && non_zero;
+  return sum <= 65535u;
 }
 
 nonnull((1,3))
@@ -59,10 +55,8 @@ static really_inline int32_t scan_int32(
 {
   uint64_t sum = (uint8_t)data[0] - '0';
 
-  if (sum > 9 || length > 10)
+  if (sum > 9 || !length || length > 10)
     return 0;
-
-  uint32_t non_zero = (sum != 0) | (length == 1);
 
   for (size_t count=1; count < length; count++) {
     const uint8_t digit = (uint8_t)data[count] - '0';
@@ -72,7 +66,7 @@ static really_inline int32_t scan_int32(
   }
 
   *number = (uint32_t)sum;
-  return sum <= 4294967295u && non_zero;
+  return sum <= 4294967295u;
 }
 
 nonnull_all

--- a/tests/time.c
+++ b/tests/time.c
@@ -51,7 +51,7 @@ void time_stamp_syntax(void **state)
     // one second over maximum value
     { "4294967296", 0, ZONE_SYNTAX_ERROR },
     // starts with zero
-    { "01", 0, ZONE_SYNTAX_ERROR },
+    { "01", 1, ZONE_SUCCESS },
     // Time specified as YYYYMMDDHHmmSS
     // bad number of digits
     { "202301010101", 0, ZONE_SYNTAX_ERROR },


### PR DESCRIPTION
Two small changes to make all NSD tests pass. Note that one of the changes is actually to allow for leading zeroes in integers. BIND and Knot (and the current parser in NSD obviously) allow for that. One benefit is that the algorithm to speed up integer deserialization outlined in #25 can be used without further modification (not this release though).