### PR TITLE
Allow kernels to be explicitly enabled/disabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,9 @@ endif()
 option(BUILD_TESTING "Build the testing tree." OFF)
 option(BUILD_DOCUMENTATION "Build documentation." OFF)
 
+option(WESTMERE "Build Westmere (SSE4.2) kernel for x86_64" ON)
+option(HASWELL "Build Haswell (AVX2) kernel for x86_64" ON)
+
 if(CMAKE_VERSION VERSION_LESS 3.20)
   # CMAKE_<LANG>_BYTE_ORDER was added in version 3.20. Mimic the option in
   # prior versions.
@@ -181,7 +184,7 @@ if(architecture STREQUAL "x86_64" OR architecture STREQUAL "amd64")
   check_c_compiler_flag("-march=westmere" HAVE_MARCH_WESTMERE)
   check_c_compiler_flag("-march=haswell" HAVE_MARCH_HASWELL)
 
-  if(HAVE_IMMINTRIN_H AND HAVE_MARCH_WESTMERE)
+  if(WESTMERE AND HAVE_IMMINTRIN_H AND HAVE_MARCH_WESTMERE)
     set(HAVE_WESTMERE TRUE)
     set_source_files_properties(
       src/westmere/parser.c PROPERTIES COMPILE_FLAGS "-march=westmere")
@@ -191,7 +194,7 @@ if(architecture STREQUAL "x86_64" OR architecture STREQUAL "amd64")
     target_sources(zone-bench PRIVATE src/westmere/bench.c)
   endif()
 
-  if(HAVE_IMMINTRIN_H AND HAVE_MARCH_HASWELL)
+  if(HASWELL AND HAVE_IMMINTRIN_H AND HAVE_MARCH_HASWELL)
     set(HAVE_HASWELL TRUE)
     set_source_files_properties(
       src/haswell/parser.c PROPERTIES COMPILE_FLAGS "-march=haswell")

--- a/configure.ac
+++ b/configure.ac
@@ -18,6 +18,18 @@ AC_CONFIG_FILES([Makefile])
 m4_include(m4/ax_check_compile_flag.m4)
 m4_version_prereq([2.70], [AC_PROG_CC], [AC_PROG_CC_STDC])
 
+AC_ARG_ENABLE(westmere, AS_HELP_STRING([--disable-westmere],[Disable Westmere (SSE4.2) kernel]))
+case "$enable_westmere" in
+  no)    enable_westmere=no ;;
+  yes|*) enable_westmere=yes ;;
+esac
+
+AC_ARG_ENABLE(haswell, AS_HELP_STRING([--disable-haswell],[Disable Haswell (AVX2) kernel]))
+case "$enable_haswell" in
+  no)    enable_haswell=no ;;
+  yes|*) enable_haswell=yes ;;
+esac
+
 # Figure out the canonical target architecture.
 AC_CANONICAL_TARGET
 
@@ -36,7 +48,8 @@ if test $x86_64 = "yes"; then
   AX_CHECK_COMPILE_FLAG([-march=westmere],,,[-Werror])
   AX_CHECK_COMPILE_FLAG([-march=haswell],,,[-Werror])
 
-  if test $ac_cv_header_immintrin_h = "yes" -a \
+  if test $enable_westmere != "no" -a \
+          $ac_cv_header_immintrin_h = "yes" -a \
           $ax_cv_check_cflags__Werror__march_westmere = "yes"
   then
     AC_DEFINE(HAVE_WESTMERE, 1, [Wether or not to compile support for SSE4.2])
@@ -45,7 +58,8 @@ if test $x86_64 = "yes"; then
     HAVE_WESTMERE=NO
   fi
 
-  if test $ac_cv_header_immintrin_h = "yes" -a \
+  if test $enable_haswell != "no" -a \
+          $ac_cv_header_immintrin_h = "yes" -a \
           $ax_cv_check_cflags__Werror__march_haswell = "yes"
   then
     AC_DEFINE(HAVE_HASWELL, 1, [Wether or not to compile support for AVX2])


### PR DESCRIPTION
Distributions may want to enable/disable specific parser kernels. The use case is not recommended, but is supported.

Fixes #172.