### PR TITLE
Always log error if file cannot be opened

### DIFF
--- a/include/zone.h
+++ b/include/zone.h
@@ -342,10 +342,14 @@ struct zone_parser;
  * By default messages are printed to stdout (info) and stderr (warnings,
  * errors). A custom log handler (callback) may be provided for better
  * integration of reporting.
+ *
+ * @note file maybe NULL if initial file does not exist.
  */
 typedef void(*zone_log_t)(
   zone_parser_t *,
   uint32_t, // priority
+  const char *, // file
+  size_t, // line
   const char *, // message
   void *); // user data
 

--- a/src/generic/format.h
+++ b/src/generic/format.h
@@ -251,18 +251,8 @@ static really_inline int32_t parse_dollar_include(
   file_t *file;
   if ((code = take_quoted_or_contiguous(parser, &include, &fields[0], token)) < 0)
     return code;
-
-  switch ((code = zone_open_file(parser, token->data, token->length, &file))) {
-    case ZONE_OUT_OF_MEMORY:
-      OUT_OF_MEMORY(parser, "Cannot open %s (%.*s), out of memory",
-                    NAME(&include), (int)token->length, token->data);
-    case ZONE_NOT_PERMITTED:
-      NOT_PERMITTED(parser, "Cannot open %s (%.*s), access denied",
-                    NAME(&include), (int)token->length, token->data);
-    case ZONE_NOT_A_FILE:
-      NOT_A_FILE(parser, "Cannot open %s (%.*s), no such file",
-                 NAME(&include), (int)token->length, token->data);
-  }
+  if ((code = zone_open_file(parser, token->data, token->length, &file)) < 0)
+    return code;
 
   name_buffer_t name;
   const name_buffer_t *origin = &parser->file->origin;

--- a/src/zone.c
+++ b/src/zone.c
@@ -483,10 +483,12 @@ int32_t zone_parse_string(
   return code;
 }
 
-zone_nonnull((1,3))
+zone_nonnull((1,5))
 static void print_message(
   zone_parser_t *parser,
   uint32_t priority,
+  const char *file,
+  size_t line,
   const char *message,
   void *user_data)
 {
@@ -495,8 +497,8 @@ static void print_message(
   assert(parser->file);
   FILE *output = priority == ZONE_INFO ? stdout : stderr;
 
-  if (parser->file->name)
-    fprintf(output, "%s:%zu: %s\n", parser->file->name, parser->file->line, message);
+  if (file)
+    fprintf(output, "%s:%zu: %s\n", file, line, message);
   else
     fprintf(output, "%s\n", message);
 }
@@ -526,8 +528,10 @@ void zone_vlog(
     memcpy(message+(sizeof(message) - 4), "...", 3);
   if (parser->options.log.callback)
     callback = parser->options.log.callback;
-
-  callback(parser, priority, message, parser->user_data);
+  assert(parser->file);
+  const char *file = parser->file->name;
+  const size_t line = parser->file->line;
+  callback(parser, priority, file, line, message, parser->user_data);
 }
 
 void zone_log(

--- a/tests/include.c
+++ b/tests/include.c
@@ -285,6 +285,39 @@ static void no_such_file_log(
 }
 
 /*!cmocka */
+void the_file_that_wasnt(void **state)
+{
+  // test parsing of nonexistent file is handled gracefully
+  zone_parser_t parser;
+  zone_options_t options;
+  zone_name_buffer_t name;
+  zone_rdata_buffer_t rdata;
+  zone_buffers_t buffers = { 1, &name, &rdata };
+  no_file_test_t test;
+  int32_t code;
+
+  memset(&options, 0, sizeof(options));
+  options.accept.callback = &no_such_file_accept;
+  options.log.callback = &no_such_file_log;
+  options.origin.octets = origin;
+  options.origin.length = sizeof(origin);
+  options.default_ttl = 3600;
+  options.default_class = 1;
+
+  (void)state;
+
+  char *non_file = temporary_name();
+  assert_non_null(non_file);
+
+  memset(&test, 0, sizeof(test));
+  code = zone_parse(&parser, &options, &buffers, non_file, &test);
+  free(non_file);
+  assert_int_equal(code, ZONE_NOT_A_FILE);
+  assert_true(test.log_count == 1);
+  assert_true(test.accept_count == 0);
+}
+
+/*!cmocka */
 void the_include_that_wasnt(void **state)
 {
   // test $INCLUDE of nonexistent file is handled gracefully


### PR DESCRIPTION
Previously only `$INCLUDE` files that could not be opened resulted in an error message. Now an error is logged if the initial file passed to `zone_parse` cannot be opened as well. Consequently, the current filename may be `NULL` in the log handler. To avoid confusion and to emphasize the current filename is only correct during execution of the log handler, I've added both the filename and line number to the `zone_log_t` `typedef`.