### PR TITLE
Annotate trailing_zeroes with no_sanitize_undefined

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -18,7 +18,7 @@ jobs:
             build_type: Debug
             build_tool_options: -j 4
             analyzer: off
-            sanitizer: address
+            sanitizer: address,undefined
           - os: macos-12
             build_type: Debug
             build_tool_options: -j 4

--- a/src/attributes.h
+++ b/src/attributes.h
@@ -18,6 +18,7 @@
 # define really_inline __forceinline
 # define never_inline __declspec(noinline)
 # define warn_unused_result
+# define no_sanitize_undefined
 
 # define likely(params) (params)
 # define unlikely(params) (params)
@@ -44,6 +45,17 @@
 #   define warn_unused_result __attribute__((warn_unused_result))
 # else
 #   define warn_unused_result
+# endif
+
+# if zone_has_attribute(no_sanitize)
+    // GCC 8.1 added the no_sanitize function attribute.
+#   define no_sanitize_undefined __attribute__((no_sanitize("undefined")))
+# elif zone_has_attribute(no_sanitize_undefined)
+    // GCC 4.9.0 added the UndefinedBehaviorSanitizer (ubsan) and the
+		// no_sanitize_undefined function attribute.
+#   define no_sanitize_undefined
+# else
+#   define no_sanitize_undefined
 # endif
 
 # define likely(params) __builtin_expect(!!(params), 1)

--- a/src/haswell/bits.h
+++ b/src/haswell/bits.h
@@ -21,6 +21,7 @@ static inline uint64_t count_ones(uint64_t bits) {
   return (uint64_t)_mm_popcnt_u64(bits);
 }
 
+no_sanitize_undefined
 static inline uint64_t trailing_zeroes(uint64_t bits) {
   return (uint64_t)__builtin_ctzll(bits);
 }

--- a/src/westmere/bits.h
+++ b/src/westmere/bits.h
@@ -20,6 +20,7 @@ static inline uint64_t count_ones(uint64_t input_num) {
   return (uint64_t)_mm_popcnt_u64(input_num);
 }
 
+no_sanitize_undefined
 static inline uint64_t trailing_zeroes(uint64_t input_num) {
   return (uint64_t)__builtin_ctzll(input_num);
 }


### PR DESCRIPTION
Zero is sometimes passed to ctz() by the indexer, but the result is discarded as the tape is advanced based on the result of popcnt().