### PR TITLE
Fix compiler warning

### DIFF
--- a/src/zone.c
+++ b/src/zone.c
@@ -492,6 +492,7 @@ static void print_message(
   const char *message,
   void *user_data)
 {
+  (void)parser;
   (void)user_data;
 
   assert(parser->file);


### PR DESCRIPTION
Fix unused parameter warning that occurred in release build.