### PR TITLE
Fix build dependencies

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -20,6 +20,7 @@ jobs:
             analyzer: off
             sanitizer: address,undefined
           - os: macos-12
+            packages: automake
             build_type: Debug
             build_tool_options: -j 4
             analyzer: off
@@ -51,12 +52,18 @@ jobs:
         run: |
           $python_base = python -m site --user-base
           Write-Output "$python_base\\bin" >> $GITHUB_PATH
-      - uses: msys2/setup-msys2@v2
+      - name: 'Install macOS packages'
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          brew install ${{matrix.packages}}
+      - name: 'Install MSYS2 packages'
+        uses: msys2/setup-msys2@v2
         if: runner.os == 'Windows' && matrix.generator == 'MinGW Makefiles'
         with:
           update: false
           release: false
-          install: make gcc
+          install: make gcc base-devel autotools autoconf-wrapper
       - name: 'Workaround for actions/runner-images#9491'
         if: runner.os == 'Linux'
         run: sudo sysctl vm.mmap_rnd_bits=28
@@ -113,3 +120,13 @@ jobs:
           cd build
           ctest -j 4 --output-on-failure -T test -C ${BUILD_TYPE:-RelWithDebInfo}
           ZONE_KERNEL=fallback ctest -j 4 --output-on-failure -T test -C ${BUILD_TYPE:-RelWithDebInfo}
+      - name: 'Build simdzone with configure + make'
+        if: runner.os != 'Windows'
+        id: test_autoconf
+        shell: bash
+        run: |
+          set -e -x
+          echo $PATH
+          autoreconf -i
+          ./configure
+          make -j 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Initial release.
+
+### Fixed
+
+- Fix makefile dependencies.

--- a/Makefile.in
+++ b/Makefile.in
@@ -9,22 +9,24 @@ WESTMERE = @HAVE_WESTMERE@
 HASWELL = @HAVE_HASWELL@
 
 CC = @CC@
-CPPFLAGS = @CPPFLAGS@ -I$(srcdir)/include -I$(srcdir)/src -I.
+CPPFLAGS = @CPPFLAGS@ -I$(SOURCE)/include -I$(SOURCE)/src -I.
 CFLAGS = @CFLAGS@
 DEPFLAGS = -MT $@ -MMD -MP -MF $(@:.o=.d)
-srcdir = @srcdir@
 VPATH = @srcdir@
 
-SOURCES = src/zone.c src/fallback/parser.c
-
-OBJECTS = $(SOURCES:.c=.o)
-NO_OBJECTS =
-
 WESTMERE_SOURCES = src/westmere/parser.c
-WESTMERE_OBJECTS = $(WESTMERE_SOURCES:.c=.o)
+WESTMERE_OBJECTS = $($(WESTMERE)_SOURCES:.c=.o)
 
 HASWELL_SOURCES = src/haswell/parser.c
-HASWELL_OBJECTS = $(HASWELL_SOURCES:.c=.o)
+HASWELL_OBJECTS = $($(HASWELL)_SOURCES:.c=.o)
+
+SOURCE = @srcdir@
+SOURCES = src/zone.c src/fallback/parser.c
+NO_SOURCES =
+OBJECTS = $(SOURCES:.c=.o) \
+          $($(WESTMERE)_SOURCES:.c=.o) \
+          $($(HASWELL)_SOURCES:.c=.o)
+DEPENDS = $(OBJECTS:.o=.d)
 
 EXPORT_HEADER = include/zone/export.h
 
@@ -33,10 +35,8 @@ EXPORT_HEADER = include/zone/export.h
 all: libzone.a
 
 clean:
-	@rm -f libzone.a
-	@rm -f $(OBJECTS) $(OBJECTS:.o=.d)
-	@rm -f $(WESTMERE_OBJECTS) $(WESTMERE_OBJECTS:.o=.d)
-	@rm -f $(HASWELL_OBJECTS) $(HASWELL_OBJECTS:.o=.d)
+	@rm -f .depend
+	@rm -f libzone.a $(OBJECTS)
 
 distclean: clean
 	@rm -f Makefile config.h config.log config.status
@@ -44,33 +44,25 @@ distclean: clean
 realclean: distclean
 	@rm -rf autom4te*
 
-libzone.a: $(EXPORT_HEADER) $(OBJECTS) $($(WESTMERE)_OBJECTS) $($(HASWELL)_OBJECTS)
-	$(AR) rcs libzone.a $(OBJECTS) $($(WESTMERE)_OBJECTS) $($(HASWELL)_OBJECTS)
-
+libzone.a: $(EXPORT_HEADER) $(OBJECTS)
+	$(AR) rcs libzone.a $(OBJECTS)
 
 $(EXPORT_HEADER):
 	@mkdir -p include/zone
 	@echo "#define ZONE_EXPORT" > include/zone/export.h
 
-$(OBJECTS):
-	@mkdir -p src/fallback
-	$(CC) $(DEPFLAGS) $(CPPFLAGS) $(CFLAGS) -o $@ -c $(srcdir)/$(@:.o=.c)
+$(WESTMERE_OBJECTS): CFLAGS += -march=westmere
+$(HASWELL_OBJECTS): CFLAGS += -march=haswell
 
-$(WESTMERE_OBJECTS):
-	@mkdir -p src/westmere
-	$(CC) $(DEPFLAGS) $(CPPFLAGS) $(CFLAGS) -march=westmere -o $@ -c $(srcdir)/$(@:.o=.c)
+$(OBJECTS): .depend
+	@mkdir -p src/fallback src/westmere src/haswell
+	$(CC) $(DEPFLAGS) $(CPPFLAGS) $(CFLAGS) -o $@ -c $(SOURCE)/$(@:.o=.c)
+	@touch $@
 
-$(HASWELL_OBJECTS):
-	@mkdir -p src/haswell
-	$(CC) $(DEPFLAGS) $(CPPFLAGS) $(CFLAGS) -march=haswell -o $@ -c $(srcdir)/$(@:.o=.c)
+.depend:
+	@cat /dev/null > $@
+	@for x in $(OBJECTS:.o=); do echo "$${x}.o: $${x}.c $${x}.d" >> $@; done
 
-src/zone.o: $(srcdir)/src/zone.c src/zone.d
-src/fallback/parser.o: $(srcdir)/src/fallback/parser.c src/fallback/parser.d
-src/westmere/parser.o: $(srcdir)/src/westmere/parser.c src/westmere/parser.d
-src/haswell/parser.o: $(srcdir)/src/haswell/parser.c src/haswell/parser.d
-
-DEPENDS := $(SOURCES:.c=.d) \
-           $($(WESTMERE)_SOURCES:.c=.d) \
-           $($(HASWELL)_SOURCES:.c=.d)
+-include .depend
 $(DEPENDS):
--include $(wildcard $(DEPENDS))
+-include $(DEPENDS)

--- a/Makefile.in
+++ b/Makefile.in
@@ -52,17 +52,22 @@ $(EXPORT_HEADER):
 	@mkdir -p include/zone
 	@echo "#define ZONE_EXPORT" > include/zone/export.h
 
-$(OBJECTS): $(SOURCES) $(SOURCES:.c=.d)
+$(OBJECTS):
 	@mkdir -p src/fallback
 	$(CC) $(DEPFLAGS) $(CPPFLAGS) $(CFLAGS) -o $@ -c $(srcdir)/$(@:.o=.c)
 
-$(WESTMERE_OBJECTS): $(WESTMERE_SOURCES) $(WESTMERE_SOURCES:.c=.d)
+$(WESTMERE_OBJECTS):
 	@mkdir -p src/westmere
 	$(CC) $(DEPFLAGS) $(CPPFLAGS) $(CFLAGS) -march=westmere -o $@ -c $(srcdir)/$(@:.o=.c)
 
-$(HASWELL_OBJECTS): $(HASWELL_SOURCES) $(HASWELL_SOURCES:.c=.d)
+$(HASWELL_OBJECTS):
 	@mkdir -p src/haswell
 	$(CC) $(DEPFLAGS) $(CPPFLAGS) $(CFLAGS) -march=haswell -o $@ -c $(srcdir)/$(@:.o=.c)
+
+src/zone.o: $(srcdir)/src/zone.c src/zone.d
+src/fallback/parser.o: $(srcdir)/src/fallback/parser.c src/fallback/parser.d
+src/westmere/parser.o: $(srcdir)/src/westmere/parser.c src/westmere/parser.d
+src/haswell/parser.o: $(srcdir)/src/haswell/parser.c src/haswell/parser.d
 
 DEPENDS := $(SOURCES:.c=.d) \
            $($(WESTMERE)_SOURCES:.c=.d) \


### PR DESCRIPTION
This fixes build dependencies. The objects depended on the source file in the build directory and not in the srcdir. Also the combined list of objects depended on the combined list of sources, causing objects to be rebuilt as the dependency tracking file for another source file was updated. The change fixes it.