### PR TITLE
Fix Build srcdir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix makefile dependencies.
+- Fix makefile to use source directory for build dependencies.

--- a/Makefile.in
+++ b/Makefile.in
@@ -61,7 +61,7 @@ $(OBJECTS): .depend
 
 .depend:
 	@cat /dev/null > $@
-	@for x in $(OBJECTS:.o=); do echo "$${x}.o: $${x}.c $${x}.d" >> $@; done
+	@for x in $(OBJECTS:.o=); do echo "$${x}.o: $(SOURCE)/$${x}.c $${x}.d" >> $@; done
 
 -include .depend
 $(DEPENDS):


### PR DESCRIPTION
Fix makefile to use source directory for build dependencies. Otherwise the objects depend on the source file from the wrong directory for out of source directory builds.