### PR TITLE
Fix problem with building on BSD-based systems (FreeBSD and others)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,6 +165,11 @@ target_include_directories(
                      $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
 target_link_libraries(zone-bench PRIVATE zone)
 
+check_include_file(endian.h HAVE_ENDIAN_H)
+if (HAVE_ENDIAN_H)
+    add_definitions(-DHAVE_ENDIAN_H=1)
+endif()
+
 check_include_file(unistd.h HAVE_UNISTD_H)
 if(NOT HAVE_UNISTD_H)
   target_include_directories(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,9 +166,6 @@ target_include_directories(
 target_link_libraries(zone-bench PRIVATE zone)
 
 check_include_file(endian.h HAVE_ENDIAN_H)
-if (HAVE_ENDIAN_H)
-    add_definitions(-DHAVE_ENDIAN_H=1)
-endif()
 
 check_include_file(unistd.h HAVE_UNISTD_H)
 if(NOT HAVE_UNISTD_H)

--- a/configure.ac
+++ b/configure.ac
@@ -18,6 +18,8 @@ AC_CONFIG_FILES([Makefile])
 m4_include(m4/ax_check_compile_flag.m4)
 m4_version_prereq([2.70], [AC_PROG_CC], [AC_PROG_CC_STDC])
 
+AC_CHECK_HEADER(endian.h, AC_DEFINE(HAVE_ENDIAN_H, 1, [Wether or not have the <endian.h> header file]))
+
 AC_ARG_ENABLE(westmere, AS_HELP_STRING([--disable-westmere],[Disable Westmere (SSE4.2) kernel]))
 case "$enable_westmere" in
   no)    enable_westmere=no ;;

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -1,3 +1,6 @@
+/* Wether or not have the <endian.h> header file */
+#undef HAVE_ENDIAN_H
+
 /* Wether or not to compile support for SSE4.2 */
 #undef HAVE_WESTMERE
 

--- a/src/generic/endian.h
+++ b/src/generic/endian.h
@@ -74,7 +74,18 @@
 #define le64toh(x) OSSwapLittleToHostInt64(x)
 
 #else
-#include <endian.h>
+
+#if defined(linux) || defined(__OpenBSD__)
+#  ifdef HAVE_ENDIAN_H
+#    include <endian.h>    /* attempt to define endianness */
+#  else
+#    include <machine/endian.h> /* on older OpenBSD */
+#  endif
+#endif
+#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__DragonFly__)
+#include <sys/endian.h> /* attempt to define endianness */
+#endif
+
 #endif
 
 #endif // ENDIAN_H

--- a/src/generic/endian.h
+++ b/src/generic/endian.h
@@ -74,6 +74,7 @@
 #define le64toh(x) OSSwapLittleToHostInt64(x)
 
 #else
+#include "config.h"
 
 #if defined(linux) || defined(__OpenBSD__)
 #  ifdef HAVE_ENDIAN_H


### PR DESCRIPTION
Some systems (e.g. old FreeBSD versions) do not have /usr/include/endian.h resulting the following build errors:

```
--- src/fallback/parser.o ---
cc -MT src/fallback/parser.o -MMD -MP -MF src/fallback/parser.d -I./include -I./src -I. -O2 -pipe  -fstack-protector-strong -fno-strict-aliasing -o src/fallback/parser.o -c ./src/fallback/parser.c
In file included from ./src/fallback/parser.c:12:
./src/generic/endian.h:77:10: error: 'endian.h' file not found with <angled> include; use "quotes" instead
#include <endian.h>
         ^~~~~~~~~~
         "endian.h"
In file included from ./src/fallback/parser.c:16:
./src/generic/number.h:98:12: warning: implicit declaration of function 'htobe16' is invalid in C99 [-Wimplicit-function-declaration]
  number = htobe16(number);
           ^
./src/generic/number.h:115:12: warning: implicit declaration of function 'htobe32' is invalid in C99 [-Wimplicit-function-declaration]
  number = htobe32(number);
           ^
...
```

I think we should use system-dependent endian.h like in [nsd/lookup3.c](https://github.com/NLnetLabs/nsd/blob/d22e1830200948c78c5d3d6566fa50af853dfffc/lookup3.c#L57):
```
#if defined(linux) || defined(__OpenBSD__)
#  ifdef HAVE_ENDIAN_H
#    include <endian.h>    /* attempt to define endianness */
#  else
#    include <machine/endian.h> /* on older OpenBSD */
#  endif
#endif
#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__DragonFly__)
#include <sys/endian.h> /* attempt to define endianness */
#endif
```
Also the corresponding nsd submodule should be updated in the master branch after the fix.
It would be nice to include this fix in nsd 4.10.1.