### PR TITLE
Fix contiguous scan of escaped content

### DIFF
--- a/src/fallback/scanner.h
+++ b/src/fallback/scanner.h
@@ -64,18 +64,17 @@ nonnull_all
 static really_inline const char *scan_contiguous(
   parser_t *parser, const char *start, const char *end)
 {
-  if (parser->file->state.is_escaped)
+  if (parser->file->state.is_escaped && start < end)
     goto escaped;
 
   while (start < end) {
     if (likely(classify[ (uint8_t)*start ] == CONTIGUOUS)) {
       if (unlikely(*start == '\\')) {
-escaped:
         if ((parser->file->state.is_escaped = (++start == end)))
           break;
+escaped:
         assert(start < end);
         parser->file->newlines.tail[0] += (*start == '\n');
-	continue;
       }
       start++;
     } else {

--- a/src/fallback/scanner.h
+++ b/src/fallback/scanner.h
@@ -75,6 +75,7 @@ escaped:
           break;
         assert(start < end);
         parser->file->newlines.tail[0] += (*start == '\n');
+	continue;
       }
       start++;
     } else {


### PR DESCRIPTION
Fix contiguous scan that starts is_escaped, this fixes the parsing of unknown RR types.