### PR TITLE
Fix quoted scan of escaped content

### DIFF
--- a/src/fallback/scanner.h
+++ b/src/fallback/scanner.h
@@ -40,9 +40,10 @@ static really_inline const char *scan_quoted(
 
   while (start < end) {
     if (*start == '\\') {
-      if ((parser->file->state.is_escaped = (++start == end)))
-        break;
+      start++;
 escaped:
+      if ((parser->file->state.is_escaped = (start == end)))
+        break;
       assert(start < end);
       *parser->file->newlines.tail += (*start == '\n');
       start++;

--- a/src/fallback/scanner.h
+++ b/src/fallback/scanner.h
@@ -35,14 +35,14 @@ nonnull_all
 static really_inline const char *scan_quoted(
   parser_t *parser, const char *start, const char *end)
 {
-  if (unlikely(parser->file->state.is_escaped))
+  if (unlikely(parser->file->state.is_escaped && start < end))
     goto escaped;
 
   while (start < end) {
     if (*start == '\\') {
-escaped:
       if ((parser->file->state.is_escaped = (++start == end)))
         break;
+escaped:
       assert(start < end);
       *parser->file->newlines.tail += (*start == '\n');
       start++;

--- a/tests/syntax.c
+++ b/tests/syntax.c
@@ -1119,3 +1119,52 @@ void contiguous_escaped_start(void** state)
     NULL);
   assert_int_equal(result, ZONE_SUCCESS);
 }
+
+/*!cmocka */
+void quoted_escaped_start(void** state)
+{
+  /* Check that the fallback parser handles a scan of a quoted segment
+   * that starts with is_escaped. */
+  char* zone =
+"$ORIGIN example.\n"
+"$TTL 3600\n"
+"@	IN	SOA	ns postmaster.mail 2147483647 3600 900 1814400 900\n"
+"	IN	NS	ns\n"
+"ns	IN	A	203.0.113.53\n"
+"ns	IN	AAAA	2001:db8:feed:beef::53\n"
+"\n"
+"0000000	IN	A	192.0.2.0\n"
+"0000000	IN	TYPE994	\\# 10 30313233343536373839\n"
+"0000001	IN	A	192.0.2.1\n"
+"0000001	IN	TYPE994	\\# 11 3031323334353637383961\n"
+"0000002	IN	A	192.0.2.2\n"
+"0000002	IN	TYPE994	\\# 12 303132333435363738396162\n"
+"0000003	IN	A	192.0.2.3\n"
+"0000003	IN	TYPE994	\\# 13 30313233343536373839616263\n"
+"0000004	IN	A	192.0.2.4\n"
+"0000004	IN	TYPE994	\\# 14 3031323334353637383961626364\n"
+"0000005	IN	A	192.0.2.5\n"
+"0000005	IN	TYPE994	\\# 15 303132333435363738396162636465\n"
+"0000006	IN	A	192.0.2.6\n"
+"0000006	IN	TXT \"aaa\\#\"\n"
+	;
+  static uint8_t origin[] = { 0 };
+  zone_parser_t parser;
+  zone_name_buffer_t name;
+  zone_rdata_buffer_t rdata;
+  zone_buffers_t buffers = { 1, &name, &rdata };
+  zone_options_t options;
+  int32_t result;
+  (void) state;
+
+  memset(&options, 0, sizeof(options));
+  options.accept.callback = contiguous_escaped_start_cb;
+  options.origin.octets = origin;
+  options.origin.length = sizeof(origin);
+  options.default_ttl = 3600;
+  options.default_class = ZONE_CLASS_IN;
+
+  result = zone_parse_string(&parser, &options, &buffers, zone, strlen(zone),
+    NULL);
+  assert_int_equal(result, ZONE_SUCCESS);
+}

--- a/tests/syntax.c
+++ b/tests/syntax.c
@@ -1076,7 +1076,7 @@ void contiguous_escaped_start(void** state)
 {
   /* Check that the fallback parser handles a scan of a contiguous segment
    * that starts with is_escaped. */
-  char* zone =
+  char* zone = PAD(
 "$ORIGIN example.\n"
 "$TTL 3600\n"
 "@	IN	SOA	ns postmaster.mail 2147483647 3600 900 1814400 900\n"
@@ -1098,7 +1098,7 @@ void contiguous_escaped_start(void** state)
 "0000005	IN	TYPE994	\\# 15 303132333435363738396162636465\n"
 "0000006	IN	A	192.0.2.6\n"
 "0000006	IN	TYPE994	\\# 16 30313233343536373839616263646566\n"
-	;
+	);
   static uint8_t origin[] = { 0 };
   zone_parser_t parser;
   zone_name_buffer_t name;
@@ -1125,7 +1125,7 @@ void quoted_escaped_start(void** state)
 {
   /* Check that the fallback parser handles a scan of a quoted segment
    * that starts with is_escaped. */
-  char* zone =
+  char* zone = PAD(
 "$ORIGIN example.\n"
 "$TTL 3600\n"
 "@	IN	SOA	ns postmaster.mail 2147483647 3600 900 1814400 900\n"
@@ -1147,7 +1147,7 @@ void quoted_escaped_start(void** state)
 "0000005	IN	TYPE994	\\# 15 303132333435363738396162636465\n"
 "0000006	IN	A	192.0.2.6\n"
 "0000006	IN	TXT \"aaa\\#\"\n"
-	;
+	);
   static uint8_t origin[] = { 0 };
   zone_parser_t parser;
   zone_name_buffer_t name;


### PR DESCRIPTION
Fix scan in fallback parser of quoted segment that starts is_escaped.