### PR TITLE
Read zone from stdin

### DIFF
--- a/src/zone.c
+++ b/src/zone.c
@@ -289,11 +289,19 @@ static int32_t open_file(
   const char *includer = "";
   if (file != &parser->first)
     includer = parser->file->path;
-  if ((code = resolve_path(includer, file->name, &file->path)))
+  if(strcmp(file->name, "-") == 0) {
+    if(!(file->path = strdup(file->name)))
+      return ZONE_OUT_OF_MEMORY;
+  } else if ((code = resolve_path(includer, file->name, &file->path)))
     return (void)close_file(parser, file), code;
 
-  if ((file->handle = fopen(file->path, "rb")))
+  if(strcmp(file->path, "-") == 0) {
+    file->handle = stdin;
     return 0;
+  } else {
+    if ((file->handle = fopen(file->path, "rb")))
+      return 0;
+  }
 
   switch (errno) {
     case ENOMEM:


### PR DESCRIPTION
This adds the feature to read a zone from stdin, with name `-`.

Fixes NLnetlabs/nsd#339