### PR TITLE
Fix contiguous escaped reset

### DIFF
--- a/src/fallback/scanner.h
+++ b/src/fallback/scanner.h
@@ -70,9 +70,10 @@ static really_inline const char *scan_contiguous(
   while (start < end) {
     if (likely(classify[ (uint8_t)*start ] == CONTIGUOUS)) {
       if (unlikely(*start == '\\')) {
-        if ((parser->file->state.is_escaped = (++start == end)))
-          break;
+	start++;
 escaped:
+        if ((parser->file->state.is_escaped = (start == end)))
+          break;
         assert(start < end);
         parser->file->newlines.tail[0] += (*start == '\n');
       }

--- a/tests/syntax.c
+++ b/tests/syntax.c
@@ -1119,3 +1119,54 @@ void contiguous_escaped_start(void** state)
     NULL);
   assert_int_equal(result, ZONE_SUCCESS);
 }
+
+/*!cmocka */
+void contiguous_escaped_reset(void** state)
+{
+  /* Check that the fallback parser resets the is_escaped value, so that
+   * a newline is not wrongly classified in the next block. */
+  char* zone = PAD(
+"$ORIGIN example.\n"
+"$TTL 3600\n"
+"@	IN	SOA	ns zonemaster.mail 2147483647 3600 900 1814400 900\n"
+"	IN	NS	ns\n"
+"ns	IN	A	203.0.113.53\n"
+"ns	IN	AAAA	2001:db8:feed:beef::53\n"
+"\n"
+"0000000	IN	A	192.0.2.0\n"
+"0000000	IN	TYPE994	\\# 6 303132333435\n"
+"0000001	IN	A	192.0.2.1\n"
+"0000001	IN	TYPE994	\\# 7 30313233343536\n"
+"0000002	IN	A	192.0.2.2\n"
+"0000002	IN	TYPE994	\\# 8 3031323334353637\n"
+"0000003	IN	A	192.0.2.3\n"
+"0000003	IN	TYPE994	\\# 9 303132333435363738\n"
+"0000004	IN	A	192.0.2.4\n"
+"0000004	IN	TYPE994	\\# 10 30313233343536373839\n"
+"0000005	IN	A	192.0.2.5\n"
+"0000005	IN	TYPE994	\\# 11 3031323334353637383961\n"
+"0000006	IN	A	192.0.2.6\n"
+"0000006	IN	TYPE994	\\# 12 303132333435363738396162\n"
+"0000007	IN	A	192.0.2.7\n"
+"0000007	IN	TYPE994	\\# 13 30313233343536373839616263\n"
+	);
+  static uint8_t origin[] = { 0 };
+  zone_parser_t parser;
+  zone_name_buffer_t name;
+  zone_rdata_buffer_t rdata;
+  zone_buffers_t buffers = { 1, &name, &rdata };
+  zone_options_t options;
+  int32_t result;
+  (void) state;
+
+  memset(&options, 0, sizeof(options));
+  options.accept.callback = contiguous_escaped_start_cb;
+  options.origin.octets = origin;
+  options.origin.length = sizeof(origin);
+  options.default_ttl = 3600;
+  options.default_class = ZONE_CLASS_IN;
+
+  result = zone_parse_string(&parser, &options, &buffers, zone, strlen(zone),
+    NULL);
+  assert_int_equal(result, ZONE_SUCCESS);
+}


### PR DESCRIPTION
Fix that fallback scanner contiguous resets is_escaped.