### PR TITLE
Fix relative include

### DIFF
--- a/src/zone.c
+++ b/src/zone.c
@@ -39,6 +39,10 @@ static const char not_a_file[] = "<string>";
 #include "config.h"
 #include "isadetection.h"
 
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
+
 #if HAVE_HASWELL
 extern int32_t zone_haswell_parse(parser_t *);
 #endif

--- a/src/zone.c
+++ b/src/zone.c
@@ -286,14 +286,18 @@ static int32_t open_file(
   file->fields.tape[0] = &file->buffer.data[0];
   file->fields.tape[1] = &file->buffer.data[0];
 
-  const char *includer = "";
-  if (file != &parser->first)
-    includer = parser->file->path;
-  if(strcmp(file->name, "-") == 0) {
-    if(!(file->path = strdup(file->name)))
-      return ZONE_OUT_OF_MEMORY;
-  } else if ((code = resolve_path(includer, file->name, &file->path)))
-    return (void)close_file(parser, file), code;
+  if(0) {
+    const char *includer = "";
+    if (file != &parser->first)
+      includer = parser->file->path;
+    if ((code = resolve_path(includer, file->name, &file->path))) {
+      return (void)close_file(parser, file), code;
+    }
+  } else {
+    file->path = strdup(file->name);
+    if(!file->path)
+      return (void)close_file(parser, file), ZONE_OUT_OF_MEMORY;
+  }
 
   if(strcmp(file->path, "-") == 0) {
     file->handle = stdin;

--- a/src/zone.c
+++ b/src/zone.c
@@ -290,7 +290,10 @@ static int32_t open_file(
     const char *includer = "";
     if (file != &parser->first)
       includer = parser->file->path;
-    if ((code = resolve_path(includer, file->name, &file->path))) {
+    if(strcmp(file->name, "-") == 0) {
+      if(!(file->path = strdup(file->name)))
+        return (void)close_file(parser, file), ZONE_OUT_OF_MEMORY;
+    } else if ((code = resolve_path(includer, file->name, &file->path))) {
       return (void)close_file(parser, file), code;
     }
   } else {

--- a/tests/include.c
+++ b/tests/include.c
@@ -557,7 +557,11 @@ void include_relative(void **state)
     mkdir(dir1, 0755)
 #endif
     != 0) {
+#if _WIN32
+    printf("mkdir %s failed\n", dir1);
+#else
     printf("mkdir %s failed: %s\n", dir1, strerror(errno));
+#endif
     fail();
   }
   if(
@@ -567,7 +571,11 @@ void include_relative(void **state)
     mkdir(dir2, 0755)
 #endif
     != 0) {
+#if _WIN32
+    printf("mkdir %s failed\n", dir2);
+#else
     printf("mkdir %s failed: %s\n", dir2, strerror(errno));
+#endif
     fail();
   }
 
@@ -583,8 +591,8 @@ void include_relative(void **state)
   assert_true(result >= 0);
   (void)fclose(handle);
 
-  handle = fopen(fname2, "wb");
-  assert_non_null(handle);
+  FILE* handle2 = fopen(fname2, "wb");
+  assert_non_null(handle2);
   char zonetext[1024+PATH_MAX];
   snprintf(zonetext, sizeof(zonetext),
 "; perform relative include\n"
@@ -592,9 +600,9 @@ void include_relative(void **state)
 "$INCLUDE %s\n"
 "mail A 1.2.3.5\n",
     fname1);
-  result = fputs(zonetext, handle);
+  result = fputs(zonetext, handle2);
   assert_true(result >= 0);
-  (void)fclose(handle);
+  (void)fclose(handle2);
 
   no_file_test_t test;
   memset(&test, 0, sizeof(test));

--- a/tests/include.c
+++ b/tests/include.c
@@ -25,6 +25,10 @@
 #include "zone.h"
 #include "diagnostic.h"
 
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
+
 typedef struct input input_t;
 struct input {
   struct {

--- a/tests/syntax.c
+++ b/tests/syntax.c
@@ -787,9 +787,12 @@ void bad_includes(void **state)
   int result = fputs(include, handle);
   assert_true(result >= 0);
   (void)fclose(handle);
-  free(path);
   code = parse(include, &count);
+
+  remove_include(path);
+  free(path);
   free(include);
+
   assert_int_equal(code, ZONE_SYNTAX_ERROR);
 }
 


### PR DESCRIPTION
This fixes relative includes in the zone file. The name should be resolved relative to the working directory. And not relative to the zone file name. This makes the resolve_path function superfluous.

There is a unit test for it in nsd. Fixes NLnetlabs/nsd#343 .