### PR TITLE
configure.ac: Fix implicit function declaration warning for -march=we…

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -76,7 +76,7 @@ AC_INCLUDES_DEFAULT
 int main(int argc, char *argv[])
 {
   (void)argv;
-  uint64_t popcnt = _mm_popcnt_64((uint64_t)argc);
+  uint64_t popcnt = _mm_popcnt_u64((uint64_t)argc);
   return popcnt == 11;
 }
 ]])


### PR DESCRIPTION
gcc/clang will complain about an implicit declaration warning when checking if '-march=westmere' works:

    conftest.c: In function 'main':
    conftest.c:56:21: error: implicit declaration of function '_mm_popcnt_64'; did you mean '_mm_popcnt_u64'? [-Wimplicit-function-declaration]
       56 |   uint64_t popcnt = _mm_popcnt_64((uint64_t)argc);
          |                     ^~~~~~~~~~~~~
          |                     _mm_popcnt_u64
    configure:3888: $? = 1

Replace '_mm_popcnt_64' with the correct '_mm_popcnt_u64' function name to resolve this.

Fixes: 380abdb96de4 ("Separate Autoconf and CMake compiler tests")