### PR TITLE
Fix handling of implicit TTLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,5 @@ $ cmake --build .
 ## Contributing
 Contributions in any way, shape or form are very welcome! Please see
 [CONTRIBUTING.md](CONTRIBUTING.md) to find out how you can help.
+
+Design decisions and notes on the [FORMAT](FORMAT.md).

--- a/include/zone.h
+++ b/include/zone.h
@@ -279,8 +279,6 @@ struct zone_rdata_buffer {
  */
 #define ZONE_TAPE_SIZE ((100 * ZONE_BLOCK_SIZE) + ZONE_BLOCK_SIZE)
 
-// @private
-
 typedef struct zone_file zone_file_t;
 struct zone_file {
   /** @private */
@@ -289,12 +287,19 @@ struct zone_file {
   zone_name_buffer_t origin, owner;
   /** @private */
   uint16_t last_type;
-  /** @private */
-  uint32_t last_ttl, default_ttl;
+  /** Last stated TTL. */
+  uint32_t last_ttl;
+  /** Last parsed TTL in $TTL entry. */
+  uint32_t dollar_ttl;
+  /** TTL passed to accept callback. */
+  uint32_t *ttl;
+  /** Default TTL passed to accept. */
+  /** Last stated TTL is used as default unless $TTL entry was found. */
+  uint32_t *default_ttl;
   /** @private */
   uint16_t last_class;
   /** Number of lines spanned by RR. */
-  /** non-terminating line feeds, i.e. escaped line feeds, line feeds in
+  /** Non-terminating line feeds, i.e. escaped line feeds, line feeds in
       quoted sections or within parentheses, are counted, but deferred for
       consistency in error reports */
   size_t span;

--- a/src/generic/types.h
+++ b/src/generic/types.h
@@ -216,7 +216,7 @@ static really_inline int32_t accept_rr(
     &(zone_name_t){ (uint8_t)parser->owner->length, parser->owner->octets },
     parser->file->last_type,
     parser->file->last_class,
-    parser->file->last_ttl,
+    *parser->file->ttl,
     (uint16_t)length,
     parser->rdata->octets,
     parser->user_data);

--- a/src/zone.c
+++ b/src/zone.c
@@ -255,14 +255,24 @@ static void initialize_file(
            parser->options.origin.length);
     file->origin.length = parser->options.origin.length;
     file->last_class = parser->options.default_class;
+    file->dollar_ttl = parser->options.default_ttl;
     file->last_ttl = parser->options.default_ttl;
+    file->ttl = file->default_ttl = &file->last_ttl;
   } else {
     assert(parser->file);
     file->includer = parser->file;
     memcpy(&file->origin, &parser->file->origin, sizeof(file->origin));
-    // retain class and TTL
+    // Retain class and TTL values.
     file->last_class = parser->file->last_class;
+    file->dollar_ttl = parser->file->dollar_ttl;
     file->last_ttl = parser->file->last_ttl;
+    // RRs appearing after the $TTL directive that do not explicitly include
+    // a TTL value, have their TTL set to the TTL in the $TTL directive. RRs
+    // appearing before a $TTL directive use the last explicitly stated value.
+    if (parser->file->default_ttl == &parser->file->last_ttl)
+      file->ttl = file->default_ttl = &file->last_ttl;
+    else
+      file->ttl = file->default_ttl = &file->dollar_ttl;
   }
 
   file->line = 1;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,7 +9,7 @@ if(HAVE_HASWELL)
   set_source_files_properties(haswell/bits.c PROPERTIES COMPILE_FLAGS "-march=haswell")
 endif()
 
-cmocka_add_tests(zone-tests types.c include.c ip4.c time.c base32.c svcb.c syntax.c semantics.c eui.c bounds.c bits.c)
+cmocka_add_tests(zone-tests types.c include.c ip4.c time.c base32.c svcb.c syntax.c semantics.c eui.c bounds.c bits.c ttl.c)
 
 set(xbounds ${CMAKE_CURRENT_SOURCE_DIR}/zones/xbounds.zone)
 set(xbounds_c "${CMAKE_CURRENT_BINARY_DIR}/xbounds.c")

--- a/tests/tools.c
+++ b/tests/tools.c
@@ -45,7 +45,7 @@ diagnostic_pop()
 #else
   tmpdir = getenv("TMPDIR");
 #endif
-  if (is_dir(tmpdir))
+  if (tmpdir && is_dir(tmpdir))
     return tmpdir;
   if (dir && is_dir(tmpdir))
     return dir;

--- a/tests/ttl.c
+++ b/tests/ttl.c
@@ -1,0 +1,174 @@
+/*
+ * ttl.c -- Test $TTL works as advertised
+ *
+ * Copyright (c) 2024, NLnet Labs. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ */
+#include <stdarg.h>
+#include <setjmp.h>
+#include <string.h>
+#include <cmocka.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "zone.h"
+#include "tools.h"
+
+struct rr_ttl {
+  size_t rr;
+  size_t ttl_count;
+  uint32_t *ttls;
+};
+
+static int32_t accept_rr(
+  zone_parser_t *parser,
+  const zone_name_t *owner,
+  uint16_t type,
+  uint16_t class,
+  uint32_t ttl,
+  uint16_t rdlength,
+  const uint8_t *rdata,
+  void *user_data)
+{
+  (void)parser;
+  (void)owner;
+  (void)type;
+  (void)class;
+  (void)rdlength;
+  (void)rdata;
+
+  struct rr_ttl *rr_ttl = user_data;
+
+  if (rr_ttl->rr >= rr_ttl->ttl_count)
+    return ZONE_SYNTAX_ERROR;
+  if (rr_ttl->ttls[rr_ttl->rr++] != ttl)
+    return ZONE_SYNTAX_ERROR;
+  return ZONE_SUCCESS;
+}
+
+/*!cmocka */
+void correct_ttl_is_used(void **state)
+{
+
+  (void)state;
+
+  struct {
+    const char *str;
+    struct rr_ttl ttls;
+  } tests[] = {
+    {
+      "$ORIGIN com.\n"
+      "example 300 IN SOA ns hostmaster 2024081901 3600 600 86400 3600\n"
+      "example     IN NS  ns\n",
+      { 0, 2, (uint32_t[]){ 300, 300 } }
+    },
+    {
+      "$ORIGIN com.\n"
+      "$TTL 350\n"
+      "example 300 IN SOA ns hostmaster 2024081901 3600 600 86400 3600\n"
+      "example     IN NS  ns\n",
+      { 0, 2, (uint32_t[]){ 300, 350 } }
+    }
+  };
+
+  for (int i=0, n=sizeof(tests)/sizeof(tests[0]); i < n; i++) {
+    size_t len = strlen(tests[i].str);
+    char *str = malloc(len + ZONE_BLOCK_SIZE + 1);
+    assert_non_null(str);
+    memcpy(str, tests[i].str, len + 1);
+
+    zone_parser_t parser;
+    zone_name_buffer_t name;
+    zone_rdata_buffer_t rdata;
+    zone_buffers_t buffers = { 1, &name, &rdata };
+    zone_options_t options;
+    const uint8_t origin[1] = { 0 };
+    int32_t code;
+
+    memset(&options, 0, sizeof(options));
+    options.accept.callback = accept_rr;
+    options.origin.octets = origin;
+    options.origin.length = sizeof(origin);
+    options.default_ttl = 3600;
+    options.default_class = 1;
+
+    code = zone_parse_string(&parser, &options, &buffers, str, (size_t)len, &tests[i].ttls);
+    free(str);
+    assert_int_equal(code, ZONE_SUCCESS);
+    assert_int_equal(tests[i].ttls.rr, tests[i].ttls.ttl_count);
+  }
+}
+
+/*!cmocka */
+void correct_ttl_is_used_in_include(void **state)
+{
+  (void)state;
+
+  struct {
+    const char *fmt;
+    const char *str;
+    struct rr_ttl ttls;
+  } tests[] = {
+    { "$ORIGIN com.\n"
+      "example 300 IN SOA ns hostmaster 2024081901 3600 600 86400 3600\n"
+      "$INCLUDE \"%s\"\n"
+      "example     IN A 192.0.2.1\n",
+      "example 600 IN A 192.0.2.2\n"
+      "example     IN A 192.0.2.3\n",
+      { 0, 4, (uint32_t[]){ 300, 600, 600, 300 } }
+    },
+    { "$ORIGIN com.\n"
+      "$TTL 350\n"
+      "example 300 IN SOA ns hostmaster 2024081901 3600 600 86400 3600\n"
+      "$INCLUDE \"%s\"\n"
+      "example     IN A 192.0.2.1\n",
+      "$TTL 650\n"
+      "example 600 IN A 192.0.2.2\n"
+      "example     IN A 192.0.2.3\n",
+      { 0, 4, (uint32_t[]){ 300, 600, 650, 350 } }
+    }
+  };
+
+  for (int i=0, n=sizeof(tests)/sizeof(tests[0]); i < n; i++) {
+    char *inc = get_tempnam(NULL, "zone");
+    assert_non_null(inc);
+
+    char buf[32];
+    int len = snprintf(buf, sizeof(buf), tests[i].fmt, inc);
+    assert_false(len < 0);
+    char *str = malloc((size_t)len + ZONE_BLOCK_SIZE + 1);
+    assert_non_null(str);
+    (void)snprintf(str, (size_t)len + 1, tests[i].fmt, inc);
+
+    FILE *handle = fopen(inc, "wb");
+    assert_non_null(handle);
+    int count = fputs(tests[i].str, handle);
+    assert_int_not_equal(count, EOF);
+    (void)fflush(handle);
+    (void)fclose(handle);
+
+    zone_parser_t parser;
+    zone_name_buffer_t name;
+    zone_rdata_buffer_t rdata;
+    zone_buffers_t buffers = { 1, &name, &rdata };
+    zone_options_t options;
+    const uint8_t origin[1] = { 0 };
+    int32_t code;
+
+    memset(&options, 0, sizeof(options));
+    options.accept.callback = accept_rr;
+    options.origin.octets = origin;
+    options.origin.length = sizeof(origin);
+    options.default_ttl = 3600;
+    options.default_class = 1;
+
+    code = zone_parse_string(&parser, &options, &buffers, str, (size_t)len, &tests[i].ttls);
+    remove(inc);
+    free(inc);
+    free(str);
+    assert_int_equal(code, ZONE_SUCCESS);
+    assert_int_equal(tests[i].ttls.rr, tests[i].ttls.ttl_count);
+  }
+}


### PR DESCRIPTION
This PR (still a draft because I need to add tests and discuss the extra parameter) fixes handling of implicit TTLs. The value from `$TTL` is used if available (propagated to `$INCLUDE`s too), otherwise the last stated TTL is used. ~~There's one scenario (two actually) where TTLs must be handled differently and that is with `SIG` and `RRSIG` RRs. I've added an additional `flags` parameter to the callback signature so that the application can detect whether the TTL was specified implicitly or explicitly. If implicit, NSD (or any other application) might choose to fix-up the TTL after the covered RRSet has been parsed. Alternatively, NSD may choose to error out if the TTL was specified explicitly and it did not match the TTLs of the RRSet? To some extend, it depends on what is the usual way to handle mismatching TTLs.~~ (functionality removed after internal discussion) @wcawijngaards, @wtoorop any thoughts on the chosen solution?