### PR TITLE
Fix double bswap

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,7 +168,15 @@ target_include_directories(
 target_link_libraries(zone-bench PRIVATE zone)
 
 check_include_file(endian.h HAVE_ENDIAN_H)
+check_include_file(sys/endian.h HAVE_SYS_ENDIAN_H)
 check_include_file(unistd.h HAVE_UNISTD_H)
+set(ENDIAN_INCLUDES "endian.h")
+if(HAVE_SYS_ENDIAN_H)
+  set(ENDIAN_INCLUDES "${ENDIAN_INCLUDES};sys/endian.h")
+endif()
+check_symbol_exists(bswap16 ${ENDIAN_INCLUDES} HAVE_DECL_BSWAP16)
+check_symbol_exists(bswap32 ${ENDIAN_INCLUDES} HAVE_DECL_BSWAP32)
+check_symbol_exists(bswap64 ${ENDIAN_INCLUDES} HAVE_DECL_BSWAP64)
 
 set(CMAKE_REQUIRED_DEFINITIONS "-D_DEFAULT_SOURCE=1")
 check_symbol_exists(getopt "stdlib.h;unistd.h" HAVE_GETOPT)

--- a/configure.ac
+++ b/configure.ac
@@ -18,7 +18,16 @@ AC_CONFIG_FILES([Makefile])
 m4_include(m4/ax_check_compile_flag.m4)
 m4_version_prereq([2.70], [AC_PROG_CC], [AC_PROG_CC_STDC])
 
-AC_CHECK_HEADER(endian.h, AC_DEFINE(HAVE_ENDIAN_H, 1, [Define to 1 if you have the <endian.h> header file.]))
+AC_CHECK_HEADERS([endian.h sys/endian.h],,, [AC_INCLUDES_DEFAULT])
+AC_CHECK_DECLS([bswap16,bswap32,bswap64], [], [], [
+AC_INCLUDES_DEFAULT
+#ifdef HAVE_ENDIAN_H
+#include <endian.h>
+#endif
+#ifdef HAVE_SYS_ENDIAN_H
+#include <sys/endian.h>
+#endif
+])
 
 AC_ARG_ENABLE(westmere, AS_HELP_STRING([--disable-westmere],[Disable Westmere (SSE4.2) kernel]))
 case "$enable_westmere" in

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -9,6 +9,18 @@
 #ifndef CONFIG_H
 #define CONFIG_H
 
+/* Define to 1 if you have the declaration of `bswap16', and to 0 if you
+   don't. */
+#cmakedefine01 HAVE_DECL_BSWAP16
+
+/* Define to 1 if you have the declaration of `bswap32', and to 0 if you
+   don't. */
+#cmakedefine01 HAVE_DECL_BSWAP32
+
+/* Define to 1 if you have the declaration of `bswap64', and to 0 if you
+   don't. */
+#cmakedefine01 HAVE_DECL_BSWAP64
+
 /* Define to 1 if you have the <endian.h> header file. */
 #cmakedefine HAVE_ENDIAN_H 1
 

--- a/src/generic/endian.h
+++ b/src/generic/endian.h
@@ -122,6 +122,7 @@
 # endif
 #endif
 
+#if !HAVE_DECL_BSWAP16
 static really_inline uint16_t bswap16(uint16_t x)
 {
   // Copied from src/common/lib/libc/gen/bswap16.c in NetBSD
@@ -129,7 +130,9 @@ static really_inline uint16_t bswap16(uint16_t x)
   // Public domain.
   return ((x << 8) & 0xff00) | ((x >> 8) & 0x00ff);
 }
+#endif
 
+#if !HAVE_DECL_BSWAP32
 static really_inline uint32_t bswap32(uint32_t x)
 {
   // Copied from src/common/lib/libc/gen/bswap32.c in NetBSD
@@ -140,7 +143,9 @@ static really_inline uint32_t bswap32(uint32_t x)
          ( (x >>  8) & 0x0000ff00 ) |
          ( (x >> 24) & 0x000000ff );
 }
+#endif
 
+#if !HAVE_DECL_BSWAP64
 static really_inline uint64_t bswap64(uint64_t x)
 {
   // Copied from src/common/lib/libc/gen/bswap64.c in NetBSD
@@ -155,6 +160,7 @@ static really_inline uint64_t bswap64(uint64_t x)
          ( (x >> 40) & 0x000000000000ff00ull ) |
          ( (x >> 56) & 0x00000000000000ffull );
 }
+#endif
 
 # if BYTE_ORDER == LITTLE_ENDIAN
 #   define htobe(bits, x) bswap ## bits((x))


### PR DESCRIPTION
Fix for double bswap definitions. On NetBSD, the sys/endian.h file has definitions for bswap16, bswap32 and bswap64. If these are included, then the redeclaration of the routines in src/generic/endian.h makes compilation fail. The fix detects in configure if the functions are declared, and if so, does not attempt to provide a function definition for them.