### PR TITLE
Fix detection of Westmere kernel

### DIFF
--- a/src/bench.c
+++ b/src/bench.c
@@ -57,7 +57,7 @@ static const kernel_t kernels[] = {
   { "haswell", AVX2, &zone_bench_haswell_lex, &zone_haswell_parse },
 #endif
 #if HAVE_WESTMERE
-  { "westmere", SSE42, &zone_bench_westmere_lex, &zone_westmere_parse },
+  { "westmere", SSE42|PCLMULQDQ, &zone_bench_westmere_lex, &zone_westmere_parse },
 #endif
   { "fallback", DEFAULT, &zone_bench_fallback_lex, &zone_fallback_parse }
 };

--- a/src/zone.c
+++ b/src/zone.c
@@ -68,7 +68,7 @@ static const kernel_t kernels[] = {
   { "haswell", AVX2, &zone_haswell_parse },
 #endif
 #if HAVE_WESTMERE
-  { "westmere", SSE42, &zone_westmere_parse },
+  { "westmere", SSE42|PCLMULQDQ, &zone_westmere_parse },
 #endif
   { "fallback", DEFAULT, &zone_fallback_parse }
 };

--- a/tests/bits.c
+++ b/tests/bits.c
@@ -55,20 +55,20 @@ extern void test_fallback_leading_zeroes(void **);
 
 static const struct kernel kernels[] = {
 #if HAVE_HASWELL
-  { "haswell", AVX2,     &test_haswell_trailing_zeroes,
-                         &test_haswell_leading_zeroes,
-                         &test_haswell_prefix_xor,
-                         &test_haswell_add_overflow },
+  { "haswell", AVX2,             &test_haswell_trailing_zeroes,
+                                 &test_haswell_leading_zeroes,
+                                 &test_haswell_prefix_xor,
+                                 &test_haswell_add_overflow },
 #endif
 #if HAVE_WESTMERE
-  { "westmere", SSE42,   &test_westmere_trailing_zeroes,
-                         &test_westmere_leading_zeroes,
-                         &test_westmere_prefix_xor,
-                         &test_westmere_add_overflow },
+  { "westmere", SSE42|PCLMULQDQ, &test_westmere_trailing_zeroes,
+                                 &test_westmere_leading_zeroes,
+                                 &test_westmere_prefix_xor,
+                                 &test_westmere_add_overflow },
 #endif
-  { "fallback", DEFAULT, &test_fallback_trailing_zeroes,
-                         &test_fallback_leading_zeroes,
-                         0, 0 }
+  { "fallback", DEFAULT,         &test_fallback_trailing_zeroes,
+                                 &test_fallback_leading_zeroes,
+                                 0, 0 }
 };
 
 static inline const struct kernel *


### PR DESCRIPTION
The Westmere kernel was selected if SSE4.2 was detected causing an illegal instruction on processors that support SSE4.2 but not CLMUL.

Fixes NLnetLabs/nsd#382.