### PR TITLE
tls-supported-groups SvcParam support

### DIFF
--- a/include/zone.h
+++ b/include/zone.h
@@ -221,8 +221,10 @@ extern "C" {
 #define ZONE_SVC_PARAM_KEY_IPV6HINT (6u)
 /** URI template in relative form @rfc{9461} */
 #define ZONE_SVC_PARAM_KEY_DOHPATH (7u)
-/** Target is an Oblivious HTTP service @draft{ohai,svcb-config} */
+/** Target is an Oblivious HTTP service @rfc{9540} */
 #define ZONE_SVC_PARAM_KEY_OHTTP (8u)
+/** Supported groups in TLS @draft{ietf, tls-key-share-prediction} */
+#define ZONE_SVC_PARAM_KEY_TLS_SUPPORTED_GROUPS (9u)
 /** Reserved ("invalid key") @rfc{9460} */
 #define ZONE_SVC_PARAM_KEY_INVALID_KEY (65535u)
 /** @} */

--- a/src/generic/parser.h
+++ b/src/generic/parser.h
@@ -49,7 +49,7 @@ struct string {
 typedef struct mnemonic mnemonic_t;
 struct mnemonic {
   struct {
-    char data[16];
+    char data[24];
     size_t length;
   } key;
   uint32_t value;


### PR DESCRIPTION
As specified in https://datatracker.ietf.org/doc/draft-ietf-tls-key-share-prediction/01/

Also:
  - draft-ietf-ohai-svcb-config became RFC 9540 for the ohttp SvcParam
  - added tests for ohttp