### PR TITLE
Remove use of getcwd for resolving paths

### DIFF
--- a/src/zone.c
+++ b/src/zone.c
@@ -134,8 +134,6 @@ static int32_t resolve_path(const char *include, char **path)
   char *resolved;
   char buffer[PATH_MAX + 1];
 
-  resolved = realpath(include, buffer);
-
   if (!(resolved = realpath(include, buffer)))
     return (errno == ENOMEM) ? ZONE_OUT_OF_MEMORY : ZONE_NOT_A_FILE;
   assert(resolved == buffer);


### PR DESCRIPTION
Call fopen with name rather than resolved path to allow use of specialized symbolic links for pipes and sockets. E.g., /dev/stdin.

Fixes NLnetLabs/nsd#380.