### PR TITLE
Cleanup westmere and haswell object files.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -43,6 +43,7 @@ all: libzone.a
 clean:
 	@rm -f .depend
 	@rm -f libzone.a $(OBJECTS) $(EXPORT_HEADER)
+	@rm -f $($(WESTMERE)_OBJECTS) $($(HASWELL)_OBJECTS)
 
 distclean: clean
 	@rm -f Makefile config.h config.log config.status


### PR DESCRIPTION
Without this `src/haswell/parser.o` and `src/westmere/parser.o` are left behind.
