### PR TITLE
Initialise padding after the file buffer

### DIFF
--- a/src/generic/parser.h
+++ b/src/generic/parser.h
@@ -318,6 +318,11 @@ static int32_t refill(parser_t *parser)
   parser->file->buffer.length += (size_t)count;
   parser->file->buffer.data[parser->file->buffer.length] = '\0';
   parser->file->end_of_file = feof(parser->file->handle) != 0;
+
+  /* After the file, there is padding, that is used by vector instructions,
+   * initialise those bytes. */
+  memset(parser->file->buffer.data+parser->file->buffer.length+1, 0,
+    ZONE_BLOCK_SIZE);
   return 0;
 }
 


### PR DESCRIPTION
The change initializes the padding after the file buffer. Otherwise checkers report use of uninitialised memory from those bytes. It zeroes the block size after the fread, so it does not have to wipe the entire buffer. For strings, that means the library caller would have to initialize them.