### PR TITLE
Fix type NSAP-PTR

### DIFF
--- a/src/generic/types.h
+++ b/src/generic/types.h
@@ -734,7 +734,7 @@ static int32_t check_nsap_ptr_rr(
     const uint8_t *o = parser->rdata->octets;
     const rdata_info_t *f = type->rdata.fields;
 
-    if ((r = check(&c, check_name(parser, type, &f[0], o, n))))
+    if ((r = check(&c, check_string(parser, type, &f[0], o, n))))
       return r;
 
     if (c != n)
@@ -776,9 +776,9 @@ static int32_t parse_nsap_ptr_rdata(
   int32_t code;
   const rdata_info_t *fields = type->rdata.fields;
 
-  if ((code = have_contiguous(parser, type, &fields[0], token)) < 0)
+  if ((code = have_contiguous_or_quoted(parser, type, &fields[0], token)) < 0)
     return code;
-  if ((code = parse_name(parser, type, &fields[0], rdata, token)) < 0)
+  if ((code = parse_string(parser, type, &fields[0], rdata, token)) < 0)
     return code;
   if ((code = take_delimiter(parser, type, token)) < 0)
     return code;

--- a/tests/types.c
+++ b/tests/types.c
@@ -233,7 +233,7 @@ static const rdata_t nsap_rdata =
 static const char nsap_ptr_text[] =
   PAD("0.0.2.6.1.0.0.0.f.f.f.f.f.f.3.3.1.e.1.0.0.0.0.0.0.0.0.0.a.5.0.0.0.8.5.0.0.0.7.4.NSAP.INT. NSAP-PTR host.example.com.");
 static const rdata_t nsap_ptr_rdata =
-  RDATA(4, 'h', 'o', 's', 't', 7, 'e', 'x', 'a', 'm', 'p', 'l', 'e', 3, 'c', 'o', 'm', 0);
+  RDATA(17, 'h', 'o', 's', 't', '.', 'e', 'x', 'a', 'm', 'p', 'l', 'e', '.', 'c', 'o', 'm', '.');
 
 static const char sig_text[] =
   PAD("big.foo.tld. SIG NXT 1 3 (  ;type-cov=NXT, alg=1, labels=3\n"


### PR DESCRIPTION
Fix type NSAP-PTR, it is encoded as a `<character-string>`.

The RR type is deprecated.