### PR TITLE
Fix tests to initialize padding

### DIFF
--- a/tests/base32.c
+++ b/tests/base32.c
@@ -76,6 +76,7 @@ void base32_syntax(void **state)
     zone_options_t options;
     int32_t result;
 
+    memset(rr, 0, sizeof(rr));
     (void)snprintf(rr, sizeof(rr), rrfmt, tests[i].base32);
 
     fprintf(stderr, "INPUT: '%s'\n", rr);

--- a/tests/bounds.c
+++ b/tests/bounds.c
@@ -160,7 +160,7 @@ void block_boundary(void **state)
 
   for (int i=0, n=sizeof(tests)/sizeof(tests[0]); i < n; i++) {
     // allocate memory instead of using a static buffer for asan
-    char *input = malloc(tests[i].length + 64);
+    char *input = calloc(tests[i].length + ZONE_BLOCK_SIZE, 1);
     assert_non_null(input);
     memcpy(input, tests[i].input, tests[i].length);
     memset(&parser, 0, sizeof(parser));

--- a/tests/include.c
+++ b/tests/include.c
@@ -112,7 +112,7 @@ int setup(void **state)
 
 #define FMT "$INCLUDE %s\n"
   len = (strlen(FMT) - 2) + strlen(input->include.path);
-  if (!(input->includer.content = malloc(len+1 + ZONE_BLOCK_SIZE)))
+  if (!(input->includer.content = calloc(len+1 + ZONE_BLOCK_SIZE, 1)))
     goto err;
   (void)snprintf(input->includer.content, len+1, FMT, input->include.path);
   if (fputs(input->includer.content, input->includer.handle) == EOF)
@@ -122,7 +122,7 @@ int setup(void **state)
 #undef FMT
 #define FMT "host.example.com. 3600 IN TXT foobar\n"
   len = strlen(FMT);
-  if (!(input->include.content = malloc(len+1 + ZONE_BLOCK_SIZE)))
+  if (!(input->include.content = calloc(len+1 + ZONE_BLOCK_SIZE, 1)))
     goto err;
   (void)snprintf(input->include.content, len+1, FMT);
   if (fputs(input->include.content, input->include.handle) == EOF)
@@ -173,7 +173,7 @@ static int32_t parse(
 
   int32_t code;
   size_t length = strlen(text);
-  char *string = malloc(length + 1 + ZONE_BLOCK_SIZE);
+  char *string = calloc(length + 1 + ZONE_BLOCK_SIZE, 1);
   assert_non_null(string);
   memcpy(string, text, length);
   string[length] = '\0';
@@ -486,7 +486,7 @@ void been_there_done_that(void **state)
   char dummy[16];
   int length = snprintf(dummy, sizeof(dummy), "$INCLUDE \"%s\"\n", path);
   assert_true(length > 0 && length < INT_MAX - ZONE_BLOCK_SIZE);
-  char *include = malloc((size_t)length + 1 + ZONE_BLOCK_SIZE);
+  char *include = calloc((size_t)length + 1 + ZONE_BLOCK_SIZE, 1);
   assert_non_null(include);
   (void)snprintf(include, (size_t)length + 1, "$INCLUDE \"%s\"\n", path);
   int result = fputs(include, handle);
@@ -693,7 +693,7 @@ diagnostic_pop()
   int len = snprintf(buf, sizeof(buf), fmt, paths[0]);
   assert_true(len > 0);
 
-  char *str = malloc((size_t)len + ZONE_BLOCK_SIZE + 1);
+  char *str = calloc((size_t)len + ZONE_BLOCK_SIZE + 1, 1);
   assert_non_null(str);
   (void)snprintf(str, (size_t)len+1, fmt, paths[0]);
 

--- a/tests/ip4.c
+++ b/tests/ip4.c
@@ -89,6 +89,7 @@ void ipv4_syntax(void **state)
     zone_options_t options;
     int32_t result;
 
+    memset(rr, 0, sizeof(rr));
     (void)snprintf(rr, sizeof(rr), "foo. A %s", tests[i].address);
 
     fprintf(stderr, "INPUT: %s\n", rr);

--- a/tests/semantics.c
+++ b/tests/semantics.c
@@ -117,10 +117,12 @@ void ds_digest_lengths(void **state)
     const int algo = tests[i].algorithm;
     const int len = tests[i].digest_length;
 
+    memset(buf, 0, sizeof(buf));
     snprintf(buf, sizeof(buf), fmt, algo + 0x30, len * 2, hex);
     code = parse_digest(buf);
     assert_int_equal(code, tests[i].code);
 
+    memset(buf, 0, sizeof(buf));
     snprintf(buf, sizeof(buf), hex_fmt, 4 + len, algo + 0x30, len * 2, hex);
     code = parse_digest(buf);
     assert_int_equal(code, tests[i].code);

--- a/tests/syntax.c
+++ b/tests/syntax.c
@@ -623,7 +623,7 @@ static int32_t parse_as_include(const char *text, size_t *count)
   char dummy[16];
   int length = snprintf(dummy, sizeof(dummy), "$INCLUDE \"%s\"\n", path);
   assert_true(length > 0 && length < INT_MAX - ZONE_BLOCK_SIZE);
-  char *include = malloc((size_t)length + 1 + ZONE_BLOCK_SIZE);
+  char *include = calloc((size_t)length + 1 + ZONE_BLOCK_SIZE, 1);
   assert_non_null(include);
   (void)snprintf(include, (size_t)length + 1, "$INCLUDE \"%s\"\n", path);
   code = parse(include, count);
@@ -782,7 +782,7 @@ void bad_includes(void **state)
   char dummy[32];
   int length = snprintf(dummy, sizeof(dummy), "$INCLUDE \"%s\" foo. bar\n", path);
   assert_true(length > 0 && length < INT_MAX - ZONE_BLOCK_SIZE);
-  char *include = malloc((size_t)length + 1 + ZONE_BLOCK_SIZE);
+  char *include = calloc((size_t)length + 1 + ZONE_BLOCK_SIZE, 1);
   assert_non_null(include);
   (void)snprintf(include, (size_t)length + 1, "$INCLUDE \"%s\" foo. bar.\n", path);
   int result = fputs(include, handle);
@@ -834,7 +834,7 @@ void include_with_origin(void **state)
   char dummy[32];
   int length = snprintf(dummy, sizeof(dummy), "$INCLUDE \"%s\" baz.", path);
   assert_true(length > 0 && length < INT_MAX - ZONE_BLOCK_SIZE);
-  char *include = malloc((size_t)length + 1 + ZONE_BLOCK_SIZE);
+  char *include = calloc((size_t)length + 1 + ZONE_BLOCK_SIZE, 1);
   assert_non_null(include);
   (void)snprintf(include, (size_t)length + 1, "$INCLUDE \"%s\" baz.", path);
 
@@ -899,7 +899,7 @@ void include_without_origin(void **state)
 #define FMT "$INCLUDE \"%s\""
   int length = snprintf(dummy, sizeof(dummy), "$INCLUDE \"%s\"", path);
   assert_true(length > 0 && length < INT_MAX - ZONE_BLOCK_SIZE);
-  char *include = malloc((size_t)length + 1 + ZONE_BLOCK_SIZE);
+  char *include = calloc((size_t)length + 1 + ZONE_BLOCK_SIZE, 1);
   assert_non_null(include);
   (void)snprintf(include, (size_t)length + 1, "$INCLUDE \"%s\"", path);
 #undef FMT
@@ -983,7 +983,7 @@ void owner_is_reinstated(void **state)
   " TXT foobar"
   int length = snprintf(dummy, sizeof(dummy), FMT, path);
   assert_true(length > 0 && length < INT_MAX - ZONE_BLOCK_SIZE);
-  char *include = malloc((size_t)length + 1 + ZONE_BLOCK_SIZE);
+  char *include = calloc((size_t)length + 1 + ZONE_BLOCK_SIZE, 1);
   assert_non_null(include);
   (void)snprintf(include, (size_t)length + 1, FMT, path);
 #undef FMT
@@ -1026,7 +1026,7 @@ void origin_is_reinstated(void **state)
   "foo TXT foobar"
   int length = snprintf(dummy, sizeof(dummy), FMT, path);
   assert_true(length > 0 && length < INT_MAX - ZONE_BLOCK_SIZE);
-  char *include = malloc((size_t)length + 1 + ZONE_BLOCK_SIZE);
+  char *include = calloc((size_t)length + 1 + ZONE_BLOCK_SIZE, 1);
   assert_non_null(include);
   (void)snprintf(include, (size_t)length + 1, FMT, path);
 #undef FMT

--- a/tests/time.c
+++ b/tests/time.c
@@ -97,7 +97,7 @@ void time_stamp_syntax(void **state)
                "                  J5D6fwFm8nN+6pBzeDQfsS3Ap3o= )"
 
     size_t size = strlen(FORMAT) + strlen(tests[i].timestamp) + ZONE_BLOCK_SIZE + 1;
-    char *rr = malloc((size_t)size + 1);
+    char *rr = calloc((size_t)size + 1, 1);
     (void)snprintf(rr, size, FORMAT, tests[i].timestamp);
 
     fprintf(stderr, "INPUT: %s\n", rr);

--- a/tests/ttl.c
+++ b/tests/ttl.c
@@ -78,6 +78,7 @@ void correct_ttl_is_used(void **state)
     char *str = malloc(len + ZONE_BLOCK_SIZE + 1);
     assert_non_null(str);
     memcpy(str, tests[i].str, len + 1);
+    memset(str+len+1, 0, ZONE_BLOCK_SIZE);
 
     zone_parser_t parser;
     zone_name_buffer_t name;
@@ -141,6 +142,7 @@ void correct_ttl_is_used_in_include(void **state)
     char *str = malloc((size_t)len + ZONE_BLOCK_SIZE + 1);
     assert_non_null(str);
     (void)snprintf(str, (size_t)len + 1, tests[i].fmt, inc);
+    memset(str+len+1, 0, ZONE_BLOCK_SIZE);
 
     FILE *handle = fopen(inc, "wb");
     assert_non_null(handle);


### PR DESCRIPTION
The zone_parse_string routine requires the caller to initialize padding. This fixes the unit tests of simdzone to initialize the padding for string buffers when the zone_parse_string routine is called. This is for the parse tests, the benchmark uses the file parse call. As a result uninitialized read warnings are no longer reported on the unit test.