### PR TITLE
check_pie: match nsd support

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -56,22 +56,22 @@ maintainer-clean: realclean
 devclean: realclean
 	@rm -rf config.h.in configure
 
-libzone.a: $(OBJECTS) $($(WESTMERE)_OBJECTS) $($(HASWELL)_OBJECTS)
+libzone.a: $(OBJECTS) $($(WESTMERE)_OBJECTS) $($(HASWELL)_OBJECTS) Makefile
 	$(AR) rcs libzone.a $(OBJECTS) $($(WESTMERE)_OBJECTS) $($(HASWELL)_OBJECTS)
 
 $(EXPORT_HEADER):
 	@mkdir -p include/zone
 	@echo "#define ZONE_EXPORT" > $(EXPORT_HEADER)
 
-$(WESTMERE_OBJECTS): $(EXPORT_HEADER) .depend
+$(WESTMERE_OBJECTS): $(EXPORT_HEADER) .depend Makefile
 	@mkdir -p src/westmere
 	$(CC) $(DEPFLAGS) $(CPPFLAGS) $(CFLAGS) -march=westmere -o $@ -c $(SOURCE)/$(@:.o=.c)
 
-$(HASWELL_OBJECTS): $(EXPORT_HEADER) .depend
+$(HASWELL_OBJECTS): $(EXPORT_HEADER) .depend Makefile
 	@mkdir -p src/haswell
 	$(CC) $(DEPFLAGS) $(CPPFLAGS) $(CFLAGS) -march=haswell -o $@ -c $(SOURCE)/$(@:.o=.c)
 
-$(OBJECTS): $(EXPORT_HEADER) .depend
+$(OBJECTS): $(EXPORT_HEADER) .depend Makefile
 	@mkdir -p src/fallback
 	$(CC) $(DEPFLAGS) $(CPPFLAGS) $(CFLAGS) -o $@ -c $(SOURCE)/$(@:.o=.c)
 	@touch $@

--- a/configure.ac
+++ b/configure.ac
@@ -18,6 +18,10 @@ AC_CONFIG_FILES([Makefile])
 m4_include(m4/ax_check_compile_flag.m4)
 m4_version_prereq([2.70], [AC_PROG_CC], [AC_PROG_CC_STDC])
 
+# Include PIE support from parent
+m4_include(../acx_nlnetlabs.m4)
+ACX_CHECK_PIE
+
 AC_CHECK_HEADERS([endian.h sys/endian.h],,, [AC_INCLUDES_DEFAULT])
 AC_CHECK_DECLS([bswap16,bswap32,bswap64], [], [], [
 AC_INCLUDES_DEFAULT


### PR DESCRIPTION
- The fedora build includes PIE and this is an attempt to preserve that behavior when building NSD, not sure if this will cause a specific problem for other use cases, but wanted to contribute this upstream
- Makefile - follow dependencies of object files so we will rebuild if the Makefile is updated with -fPIE for example