### PR TITLE
autotools: query for ar(1) with AC_PROG_AR

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -11,6 +11,7 @@ HASWELL = @HAVE_HASWELL@
 CC = @CC@
 CPPFLAGS = @CPPFLAGS@ -Iinclude -I$(SOURCE)/include -I$(SOURCE)/src -I.
 CFLAGS = @CFLAGS@
+AR = @AR@
 DEPFLAGS = @DEPFLAGS@
 VPATH = @srcdir@
 

--- a/configure.ac
+++ b/configure.ac
@@ -21,6 +21,8 @@ m4_include(m4/ax_check_compile_flag.m4)
 CFLAGS="$CFLAGS"
 m4_version_prereq([2.70], [AC_PROG_CC], [AC_PROG_CC_STDC])
 
+AC_PROG_AR
+
 # allow user to override the -g -O2 flags.
 if test "x$CFLAGS" = "x" ; then
 ACX_CHECK_COMPILER_FLAG(g, [CFLAGS="$CFLAGS -g"])


### PR DESCRIPTION
As it needs to match the --host architecture.

Tested against nsd-4.14.2
