### PR TITLE
Add riscv fallback detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,6 +240,8 @@ if(architecture STREQUAL "x86_64" OR architecture STREQUAL "amd64")
       target_sources(zone-bench PRIVATE src/haswell/bench.c)
     endif()
   endif()
+elseif(architecture MATCHES "^riscv")
+  message(STATUS "RISC-V target detected; building fallback kernel only")
 endif()
 
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ instructions for parsing structured text can significantly boost performance.
 simdzone, whose name is a play on [simdjson][simdjson], aims to achieve a
 similar performance boost for parsing zone data.
 
-> Currently SSE4.2 and AVX2 are supported, a fallback is used otherwise.
+> Currently SSE4.2 and AVX2 are supported. RISC-V and other non-x86_64 targets use the fallback kernel until a dedicated SIMD backend is added.
 
 > simdzone copies some code from the [simdjson][simdjson] project, with
 > permission to use and distribute it under the terms of

--- a/src/isadetection.h
+++ b/src/isadetection.h
@@ -107,6 +107,12 @@ static inline uint32_t detect_supported_architectures(void) {
 
 #endif
 
+#elif defined(__riscv)
+
+static inline uint32_t detect_supported_architectures(void) {
+  return DEFAULT;
+}
+
 #elif defined(__x86_64__) || defined(_M_AMD64) // x64
 
 // Can be found on Intel ISA Reference for CPUID


### PR DESCRIPTION
## Why

simdzone currently ships x86_64-specific SIMD kernels for Westmere and Haswell, plus a generic fallback parser. That fallback is the right conservative baseline for `riscv64` until a dedicated RISC-V SIMD backend exists. However, `src/isadetection.h` still checks raw x64 target macros directly, so forced-target validation on an x86_64 host can incorrectly enter the cpuid-based x64 detection path instead of the generic fallback path expected for `riscv64`.

## What changed

- Add an explicit `__riscv` branch to `src/isadetection.h` that returns `DEFAULT`, so RISC-V resolves to the existing fallback parser instead of inheriting x64 ISA detection.
- Update `CMakeLists.txt` to emit a clear configure-time status message when the target processor matches `riscv*`, documenting that only the fallback kernel is built.
- Update `README.md` to state that RISC-V and other non-x86_64 targets currently use the fallback kernel until a dedicated SIMD backend is added.

## Verification

- Ran the native CMake/Ninja build successfully:
  - `cmake -S . -B build-native -G Ninja -DBUILD_TESTING=OFF -DBUILD_DOCUMENTATION=OFF`
  - `cmake --build build-native --parallel 4`
- Ran a real `riscv64` cross build and install with `dockcross/linux-riscv64`:
  - `cmake -S /repo -B /tmp/simdzone-build -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=riscv64 -DCMAKE_C_COMPILER="$CC" -DCMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY -DBUILD_TESTING=OFF`
  - `cmake --build /tmp/simdzone-build --parallel 4`
  - `cmake --install /tmp/simdzone-build --prefix /tmp/simdzone-install`
- Linked a minimal `zone_parse_string` consumer against the installed `libzone.a`:
  - `"$CC" -std=c99 -O2 -static -I/tmp/simdzone-install/include simdzone_smoke.c /tmp/simdzone-install/lib/libzone.a -o /tmp/simdzone_smoke.riscv64`
- Verified the produced binary is a real RISC-V ELF:
  - `file /tmp/simdzone_smoke.riscv64`
  - `readelf -h /tmp/simdzone_smoke.riscv64`
- Ran the binary under `qemu-riscv64` successfully:
  - output: `simdzone-ok count=1 ttl=3600 addr=192.0.2.1`

## Notes

This is a conservative portability patch. It does not add RVV or any dedicated RISC-V SIMD implementation. The goal is to make `riscv64` route cleanly to simdzone's existing fallback kernel and to keep x86_64-specific ISA detection from leaking into RISC-V validation.